### PR TITLE
Fix: remove duplicate slashes in npm registry url

### DIFF
--- a/vscode/src/api/index/npm-index-server.ts
+++ b/vscode/src/api/index/npm-index-server.ts
@@ -17,7 +17,10 @@ export const versions = (
       resolve(cached);
       return;
     }
-    const url = `${indexServerURL}/${currentVersion ? `/-/package/${name}/dist-tags` : `/${name}`}`;
+    if (!indexServerURL.endsWith('/') {
+      indexServerURL += '/';
+    }
+    const url = `${indexServerURL}${currentVersion ? `-/package/${name}/dist-tags` : name}`;
     const options = getReqOptions(url);
     if (!currentVersion) {
       options.headers = {


### PR DESCRIPTION
Some mirrors do not support urls with duplicate slashes.

See: https://registry.npmmirror.com//typescript