### PR TITLE
Update npm-index-server and fetcher to handle URL cleaning

### DIFF
--- a/vscode/src/api/index/npm-index-server.ts
+++ b/vscode/src/api/index/npm-index-server.ts
@@ -1,8 +1,8 @@
 import * as https from "https";
 import NodeCache from "node-cache";
+import { Settings } from "../../config";
 import { CrateMetadatas } from "../crateMetadatas";
 import { getReqOptions } from "../utils";
-import { Settings } from "../../config";
 const cache = new NodeCache({ stdTTL: 60 * 10 });
 
 export const versions = (
@@ -17,7 +17,7 @@ export const versions = (
       resolve(cached);
       return;
     }
-    const url = `${indexServerURL}/${currentVersion ? `/-/package/${name}/dist-tags` : `/${name}`}`;
+    const url = `${indexServerURL}/${currentVersion ? `-/package/${name}/dist-tags` : `${name}`}`;
     const options = getReqOptions(url);
     if (!currentVersion) {
       options.headers = {

--- a/vscode/src/core/fetchers/fetcher.ts
+++ b/vscode/src/core/fetchers/fetcher.ts
@@ -14,7 +14,13 @@ export abstract class Fetcher {
       openSettingsDialog(urlKey, "Please set the URL for the fetcher");
       return;
     }
-    this.URL = url;
+    // delete double slashes in the URL
+    let clean_url = url.replace("///", "");
+    // delete trailing slashes in the URL
+    if (clean_url.endsWith("/")) {
+      clean_url = clean_url.slice(0, -1);
+    }
+    this.URL = clean_url;
     this.ignoreUnstable = this.ignoreUnstable;
   }
 }


### PR DESCRIPTION
- Update npm-index-server.ts to fix the URL construction for versions endpoint
- Update fetcher.ts to clean the URL by removing double slashes and trailing slashes