### PR TITLE
feat: omit npmrc config private org registries

### DIFF
--- a/vscode/src/core/listeners/JsonListener.ts
+++ b/vscode/src/core/listeners/JsonListener.ts
@@ -15,9 +15,10 @@ export class JsonListener implements Listener {
 		public lang: Language
 	) {
   }
-  async parseAndDecorate(editor: TextEditor) {
+  async parseAndDecorate(editor: TextEditor, filterDeps?: (deps: Item[]) => Item[]){
     try {
       dependencies = this.parser.parse(editor.document);
+      dependencies = filterDeps ? filterDeps(dependencies) : dependencies;
 
       if (!fetchedLatest || !fetchedLatestsMap) {
         const latestResult = await this.fetcher.versions(dependencies);

--- a/vscode/src/core/listeners/NpmListener.ts
+++ b/vscode/src/core/listeners/NpmListener.ts
@@ -1,9 +1,12 @@
+import path from "node:path";
+import { TextEditor, Uri, workspace } from "vscode";
 import Dependency from "../Dependency";
 import { Fetcher } from "../fetchers/fetcher";
 import Item from "../Item";
 import { Language } from "../Language";
 import { Parser } from "../parsers/parser";
 import { JsonListener } from "./JsonListener";
+import { Settings } from "../../config";
 
 export class NpmListener extends JsonListener {
 	constructor(
@@ -12,6 +15,56 @@ export class NpmListener extends JsonListener {
 	) {
 		super(fetcher, parser, Language.JS)
   }
+
+	async parseAndDecorate(editor: TextEditor) {
+		let namespaces = await this.parsePrivateNameSpaces(editor);
+
+		super.parseAndDecorate(editor, (dependencies) => { 
+			if (!namespaces.length) {
+				return dependencies;
+			}
+
+			return dependencies.filter(item => namespaces.every(ms => !item.key.startsWith(`${ms}/`)))
+		});
+	}
+
+	async parsePrivateNameSpaces(editor: TextEditor) {
+		let namespaces: string[] = [];
+
+		try {
+			const packageDir = path.dirname(editor.document.fileName);
+			const dotNpmrcUri = Uri.parse(path.join(packageDir, '.npmrc'));
+			const buf = await workspace.fs.readFile(dotNpmrcUri);
+			const content = buf.toString();
+			const lines = content.split('\n');
+			const replacePattern = /\s*=\s*/;
+	
+			const padUrl = (url: string) => url.endsWith('/') ? url : `${url}/`;
+			const configIndex = padUrl(Settings.npm.index);
+	
+			lines.forEach(line => {
+				const trimmedLine = line.trim();
+
+				// ignore comments
+				if (trimmedLine.startsWith(';') || trimmedLine.startsWith('#')) {
+					return
+				}
+	
+				if (trimmedLine) {
+					const [name, index] = trimmedLine.replace(replacePattern, '=').split(':registry=');
+
+					// if the index is not the same as the config index
+					if (name && index && configIndex !== padUrl(index)) {
+						namespaces.push(name);
+					}
+				}
+			});
+	
+		} catch (e) {
+			console.error(e);
+		}
+		return namespaces;
+	}
 }
 
 var dependencies: Item[];


### PR DESCRIPTION
I like this plugin very much! However, when I open a project with private org registries configured, the dependi will always be loading. After troubleshooting, I found the reason

<img width="790" alt="image" src="https://github.com/user-attachments/assets/acc4c317-1bfc-4128-8303-993a7d7454ce">

Our company's private npm caused this problem. I thought about getting private registries and then replacing the fetch url, but two reasons changed my mind.
1. The structure returned by the private npm service is uncertain.
2. Private npm packages have their own version management methods.

So I just ignored these packages. I'd love to hear your opinions.