### PR TITLE
fix: Trim whitespace from package name in PypiParser

### DIFF
--- a/vscode/src/core/parsers/PypiParser.ts
+++ b/vscode/src/core/parsers/PypiParser.ts
@@ -82,7 +82,7 @@ function parseDependencyLine(line: TextLine): Item {
 
   const item = new Item();
   item.copyFrom(
-    name,
+    name.trim(),
     version,
     startOfVersion,
     endOfVersion,


### PR DESCRIPTION
closes #80 