### PR TITLE
refactor: Updated scenarios for checkVersion function.

### DIFF
--- a/vscode/src/semver/semverUtils.ts
+++ b/vscode/src/semver/semverUtils.ts
@@ -3,7 +3,7 @@ import { Settings } from "../config";
 import { CurrentLanguage, Language } from "../core/Language";
 
 
-export function checkVersion(version: string = "0.0.0", versions: string[]): [boolean, boolean, string | null] {
+export function checkVersion(version: string = "0.0.0", versions: string[], lockedAt?: string): [boolean, boolean, string | null] {
   let v = version;
 
   v = versionToSemver(v);
@@ -14,16 +14,19 @@ export function checkVersion(version: string = "0.0.0", versions: string[]): [bo
   if (prefix > 47 && prefix < 58)
     v = "^" + v;
   const max = versions[0];
-  if (maxSatisfying(versions, v) === null) {
-    if (valid(version) === null) {
-      return [false, false, null];
+  if (lockedAt) {
+    if (!satisfies(lockedAt, v)) {
+      return [false, false, version];
     }
-    // TODO: ask this test with kaan
+    return [lockedAt === versions[0], false, lockedAt];
+  }
+  if (max) {
     const minV = minVersion(v)?.toString() ?? '0.0.0';
     if (gt(minV, max)) {
-      return [true, false, v];
+      return [true, false, version];
     }
   }
+
   // if check patch is true, check if the patch version is the same or higher than the current version
   let shouldPatchBeChecked = false;
   switch (CurrentLanguage) {

--- a/vscode/src/ui/decoration.ts
+++ b/vscode/src/ui/decoration.ts
@@ -37,14 +37,7 @@ export default function decoration(
 ): [DecorationOptions, DecorationType] {
   // Also handle json valued dependencies
   let version = item.value?.replace(",", "");
-  let satisfies, hasPatchUpdate, maxSatisfying;
-  if (item.lockedAt) {
-    maxSatisfying = version;
-    satisfies = version === versions[0];
-    hasPatchUpdate = false;
-  } else {
-    [satisfies, hasPatchUpdate, maxSatisfying] = checkVersion(version, versions);
-  }
+  let [satisfies, hasPatchUpdate, maxSatisfying] = checkVersion(version, versions, item.lockedAt);
 
   const formatError = (error: string) => {
     // Markdown does not like newlines in middle of emphasis, or spaces next to emphasis characters.


### PR DESCRIPTION
---

### Description

This PR introduces improvements to the version-checking logic with a focus on scenarios involving locked values and version comparisons in manifest files.

#### Key Changes:
1. **No locked value:**
   - When there is no locked value available, the behavior remains unchanged. The version is considered valid and will display a tick (`✔️`) **only if the version specified in the manifest file is greater than the maximum version listed.**(This update is intended to address an issue experienced by a user who encountered problems with the previous implementation.)

2. **Locked value exists but doesn't satisfy the version in the manifest file:**
   - If a locked value is present, but it **does not satisfy the version** specified in the manifest file, the UI will display an `X` (`❌`) to indicate a version mismatch.

3. **Locked value satisfies the manifest file version:**
   - If the locked value **satisfies the version** in the manifest file, the comparison checks if the locked value matches the maximum version:
     - **If the locked value is the maximum version**, display a tick (`✔️`).
     - **If the locked value is not the maximum version**, display an `X` (`❌`).

#### Important Notes:
- When the term "no locked value" is mentioned, it means the manifest file version will be used instead of any locked value.

These changes aim to provide clearer and more accurate feedback to users regarding version validation in the presence or absence of locked values.