### PR TITLE
refactor: ignoreUnstable settings change to unstableFilter

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -76,26 +76,26 @@ While Dependi works out-of-the-box without any configuration, we also offer a fe
 - `dependi.rust.enabled`: Enable Rust package management.
 - `dependi.rust.lockFileEnabled` : Enable checking for Rust dependencies in lockfiles.
 - `dependi.rust.indexServerURL`: The URL for the Rust package index server.
-- `dependi.rust.excludeUnstableVersions`: Exclude unstable versions from Rust package lists.
+- `dependi.rust.unstableFilter`: Filter unstable versions: Exclude, Include Always, or Include If Unstable.
 - `dependi.rust.ignoreLinePattern`: Matches lines based on `*` position: `text*`, `*text`, `*text*`. Multiple patterns can be used, separated by commas.
 - `dependi.npm.enabled`: Enable NPM package management.
 - `dependi.npm.lockFileEnabled`:  Enable checking for Npm dependencies in lockfiles.
 - `dependi.npm.indexServerURL`: The URL for the NPM package index server.
-- `dependi.npm.excludeUnstableVersions`: Exclude unstable versions from NPM package lists.
+- `dependi.npm.unstableFilter`: Filter unstable versions: Exclude, Include Always, or Include If Unstable.
 - `dependi.npm.ignoreLinePattern`: Matches lines based on `*` position: `text*`, `*text`, `*text*`. Multiple patterns can be used, separated by commas.
 - `dependi.go.enabled`: Enable Go package management.
 - `dependi.go.indexServerURL`: The URL for the Go package index server.
-- `dependi.go.excludeUnstableVersions`: Exclude unstable versions from Go package lists.
+- `dependi.go.unstableFilter`: Filter unstable versions: Exclude, Include Always, or Include If Unstable.
 - `dependi.go.ignoreLinePattern`: Matches lines based on `*` position: `text*`, `*text`, `*text*`. Multiple patterns can be used, separated by commas.
 - `dependi.python.enabled`: Enable Python package management.
 - `dependi.python.lockFileEnabled`: Enable checking for Python dependencies in lockfiles.
 - `dependi.python.indexServerURL`: The URL for the Python package index server.
-- `dependi.python.excludeUnstableVersions`: Exclude unstable versions from Python package lists.
+- `dependi.python.unstableFilter`: Filter unstable versions: Exclude, Include Always, or Include If Unstable.
 - `dependi.python.ignoreLinePattern`: Matches lines based on `*` position: `text*`, `*text`, `*text*`. Multiple patterns can be used, separated by commas.
 - `dependi.php.enabled`: Enable PHP package management.
 - `dependi.php.lockFileEnabled`: Enable checking for PHP dependencies in lockfiles.
 - `dependi.php.indexServerURL`: The URL for the PHP package index server.
-- `dependi.php.excludeUnstableVersions`: Exclude unstable versions from PHP package lists.
+- `dependi.php.unstableFilter`: Filter unstable versions: Exclude, Include Always, or Include If Unstable.
 - `dependi.php.ignoreLinePattern`: Matches lines based on `*` position: `text*`, `*text`, `*text*`. Multiple patterns can be used, separated by commas.
 - `dependi.vulnerability.enabled`: Enable checking for vulnerabilities in dependencies.
 - `dependi.vulnerability.ghsa.enabled`: Include GitHub Security Advisory vulnerabilities in checks.

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -216,11 +216,21 @@
             "default": "https://index.crates.io",
             "order": 5
           },
-          "dependi.rust.excludeUnstableVersions": {
-            "type": "boolean",
+          "dependi.rust.unstableFilter": {
+            "type": "string",
+            "enum": [
+              "exclude",
+              "includeAlways",
+              "includeIfUnstable"
+            ],
+            "default": "exclude",
             "scope": "resource",
-            "default": true,
-            "description": "Exclude unstable versions from Rust package lists.",
+            "enumDescriptions": [
+              "Exclude them (default)",
+              "Include them and always consider as latest",
+              "Include if the current version is already unstable"
+            ],
+            "description": "Filter unstable versions: Exclude, Include Always, or Include If Unstable.",
             "order": 6
           },
           "dependi.rust.ignoreLinePatterns": {
@@ -265,11 +275,21 @@
             "pattern": "^https?://(?!.*//)([^/]+/)*[^/]+$",
             "order": 11
           },
-          "dependi.npm.excludeUnstableVersions": {
-            "type": "boolean",
+          "dependi.npm.unstableFilter": {
+            "type": "string",
+            "enum": [
+              "exclude",
+              "includeAlways",
+              "includeIfUnstable"
+            ],
+            "default": "exclude",
             "scope": "resource",
-            "default": true,
-            "description": "Exclude unstable versions from NPM package lists.",
+            "enumDescriptions": [
+              "Exclude them (default)",
+              "Include them and always consider as latest",
+              "Include if the current version is already unstable"
+            ],
+            "description": "Filter unstable versions: Exclude, Include Always, or Include If Unstable.",
             "order": 12
           },
           "dependi.npm.ignoreLinePatterns": {
@@ -314,11 +334,21 @@
             "default": "https://proxy.golang.org",
             "order": 17
           },
-          "dependi.go.excludeUnstableVersions": {
-            "type": "boolean",
+          "dependi.go.unstableFilter": {
+            "type": "string",
+            "enum": [
+              "exclude",
+              "includeAlways",
+              "includeIfUnstable"
+            ],
+            "default": "exclude",
             "scope": "resource",
-            "default": true,
-            "description": "Exclude unstable versions from Go package lists.",
+            "enumDescriptions": [
+              "Exclude them (default)",
+              "Include them and always consider as latest",
+              "Include if the current version is already unstable"
+            ],
+            "description": "Filter unstable versions: Exclude, Include Always, or Include If Unstable.",
             "order": 18
           },
           "dependi.go.ignoreLinePatterns": {
@@ -356,11 +386,21 @@
             "default": "https://pypi.org/pypi",
             "order": 22
           },
-          "dependi.python.excludeUnstableVersions": {
-            "type": "boolean",
+          "dependi.python.unstableFilter": {
+            "type": "string",
+            "enum": [
+              "exclude",
+              "includeAlways",
+              "includeIfUnstable"
+            ],
+            "default": "exclude",
             "scope": "resource",
-            "default": true,
-            "description": "Exclude unstable versions from Python package lists.",
+            "enumDescriptions": [
+              "Exclude them (default)",
+              "Include them and always consider as latest",
+              "Include if the current version is already unstable"
+            ],
+            "description": "Filter unstable versions: Exclude, Include Always, or Include If Unstable.",
             "order": 23
           },
           "dependi.python.ignoreLinePatterns": {
@@ -405,11 +445,21 @@
             "default": "https://repo.packagist.org",
             "order": 28
           },
-          "dependi.php.excludeUnstableVersions": {
-            "type": "boolean",
+          "dependi.php.unstableFilter": {
+            "type": "string",
+            "enum": [
+              "exclude",
+              "includeAlways",
+              "includeIfUnstable"
+            ],
+            "default": "exclude",
             "scope": "resource",
-            "default": true,
-            "description": "Exclude unstable versions from PHP package lists.",
+            "enumDescriptions": [
+              "Exclude them (default)",
+              "Include them and always consider as latest",
+              "Include if the current version is already unstable"
+            ],
+            "description": "Filter unstable versions: Exclude, Include Always, or Include If Unstable.",
             "order": 29
           },
           "dependi.php.ignoreLinePatterns": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -219,11 +219,11 @@
           "dependi.rust.unstableFilter": {
             "type": "string",
             "enum": [
-              "exclude",
-              "includeAlways",
-              "includeIfUnstable"
+              "Exclude",
+              "IncludeAlways",
+              "IncludeIfUnstable"
             ],
-            "default": "exclude",
+            "default": "Exclude",
             "scope": "resource",
             "enumDescriptions": [
               "Exclude them (default)",
@@ -278,11 +278,11 @@
           "dependi.npm.unstableFilter": {
             "type": "string",
             "enum": [
-              "exclude",
-              "includeAlways",
-              "includeIfUnstable"
+              "Exclude",
+              "IncludeAlways",
+              "IncludeIfUnstable"
             ],
-            "default": "exclude",
+            "default": "Exclude",
             "scope": "resource",
             "enumDescriptions": [
               "Exclude them (default)",
@@ -337,11 +337,11 @@
           "dependi.go.unstableFilter": {
             "type": "string",
             "enum": [
-              "exclude",
-              "includeAlways",
-              "includeIfUnstable"
+              "Exclude",
+              "IncludeAlways",
+              "IncludeIfUnstable"
             ],
-            "default": "exclude",
+            "default": "Exclude",
             "scope": "resource",
             "enumDescriptions": [
               "Exclude them (default)",
@@ -389,11 +389,11 @@
           "dependi.python.unstableFilter": {
             "type": "string",
             "enum": [
-              "exclude",
-              "includeAlways",
-              "includeIfUnstable"
+              "Exclude",
+              "IncludeAlways",
+              "IncludeIfUnstable"
             ],
-            "default": "exclude",
+            "default": "Exclude",
             "scope": "resource",
             "enumDescriptions": [
               "Exclude them (default)",
@@ -448,11 +448,11 @@
           "dependi.php.unstableFilter": {
             "type": "string",
             "enum": [
-              "exclude",
-              "includeAlways",
-              "includeIfUnstable"
+              "Exclude",
+              "IncludeAlways",
+              "IncludeIfUnstable"
             ],
-            "default": "exclude",
+            "default": "Exclude",
             "scope": "resource",
             "enumDescriptions": [
               "Exclude them (default)",

--- a/vscode/src/api/indexes/dependi/indexes.ts
+++ b/vscode/src/api/indexes/dependi/indexes.ts
@@ -1,7 +1,7 @@
 import { window } from "vscode";
 import { request } from ".";
 
-import { Configs } from "../../../config";
+import { Configs, UnstableFilter } from "../../../config";
 import Dependency from "../../../core/Dependency";
 import { Logger } from "../../../extension";
 import { openDeviceLimitDialog, openPaymentRequiredDialog, openSettingsDialog } from "../../../ui/dialogs";
@@ -20,7 +20,7 @@ export interface VersionsResp {
 export interface VersionsReq {
   Language: Language;
   Packages: Item[];
-  IgnoreUnstables: string;
+  IgnoreUnstables: UnstableFilter;
   Dependencies?: Dependency[] | VersionsResp[];
   VulnerabilityCheck: boolean;
   GhsaCheck?: boolean;

--- a/vscode/src/api/indexes/dependi/indexes.ts
+++ b/vscode/src/api/indexes/dependi/indexes.ts
@@ -7,6 +7,7 @@ import { Logger } from "../../../extension";
 import { openDeviceLimitDialog, openPaymentRequiredDialog, openSettingsDialog } from "../../../ui/dialogs";
 import { Errors, getError } from "./errors";
 import { Language } from "./reports";
+import Item from "../../../core/Item";
 
 export interface VersionsResp {
   Name: string;
@@ -18,8 +19,8 @@ export interface VersionsResp {
 
 export interface VersionsReq {
   Language: Language;
-  Packages: string[];
-  IgnoreUnstables: boolean;
+  Packages: Item[];
+  IgnoreUnstables: string;
   Dependencies?: Dependency[] | VersionsResp[];
   VulnerabilityCheck: boolean;
   GhsaCheck?: boolean;

--- a/vscode/src/api/indexes/npm.ts
+++ b/vscode/src/api/indexes/npm.ts
@@ -55,7 +55,7 @@ const setVersions = (response: any, versions: string[]) => {
       versionData.forEach(([key, value]: [string, any]) => {
         if (
           !value.deprecated &&
-          (!Settings.npm.ignoreUnstable || !key.includes("-"))
+          (Settings.npm.unstableFilter !== "exclude" || !key.includes("-"))
         ) {
           versions.push(key);
         }

--- a/vscode/src/config.ts
+++ b/vscode/src/config.ts
@@ -174,34 +174,34 @@ export const Settings = {
     // fill in the settings
     this.rust.enabled = config.get<boolean>(Configs.RUST_ENABLED) ?? true;
     this.rust.index = config.get<string>(Configs.RUST_INDEX_SERVER_URL) || "https://index.crates.io";
-    this.rust.unstableFilter = updateUnstableSettings(Configs.RUST_UNSTABLE_FILTER, Configs.RUST_UNSTABLE_OLD);
+    this.rust.unstableFilter = migrateUnstableSettings(Configs.RUST_UNSTABLE_FILTER, Configs.RUST_UNSTABLE_OLD);
     this.rust.ignoreLinePattern = config.get<string>(Configs.RUST_IGNORE_LINE_PATTERN) || "";
     this.rust.informPatchUpdates = config.get<boolean>(Configs.RUST_INFORM_PATCH_UPDATES) ?? false;
     this.rust.lockFileEnabled = config.get<boolean>(Configs.RUST_ENABLED_LOCK_FILE) ?? true;
     
     this.npm.enabled = config.get<boolean>(Configs.NPM_ENABLED) ?? true;
     this.npm.index = config.get<string>(Configs.NPM_INDEX_SERVER_URL) || "https://registry.npmjs.org";
-    this.npm.unstableFilter = updateUnstableSettings(Configs.NPM_UNSTABLE_FILTER, Configs.NPM_UNSTABLE_OLD);
+    this.npm.unstableFilter = migrateUnstableSettings(Configs.NPM_UNSTABLE_FILTER, Configs.NPM_UNSTABLE_OLD);
     this.npm.ignoreLinePattern = config.get<string>(Configs.NPM_IGNORE_LINE_PATTERN) || "";
     this.npm.informPatchUpdates = config.get<boolean>(Configs.NPM_INFORM_PATCH_UPDATES) ?? false;
     this.npm.lockFileEnabled = config.get<boolean>(Configs.NPM_ENABLED_LOCK_FILE) ?? true;
 
     this.php.enabled = config.get<boolean>(Configs.PHP_ENABLED) ?? true;
     this.php.index = config.get<string>(Configs.PHP_INDEX_SERVER_URL) || "https://repo.packagist.org";
-    this.php.unstableFilter = updateUnstableSettings(Configs.PHP_UNSTABLE_FILTER, Configs.PHP_UNSTABLE_OLD);
+    this.php.unstableFilter = migrateUnstableSettings(Configs.PHP_UNSTABLE_FILTER, Configs.PHP_UNSTABLE_OLD);
     this.php.ignoreLinePattern = config.get<string>(Configs.PHP_IGNORE_LINE_PATTERN) || "";
     this.php.informPatchUpdates = config.get<boolean>(Configs.PHP_INFORM_PATCH_UPDATES) ?? false;
     this.php.lockFileEnabled = config.get<boolean>(Configs.PHP_ENABLED_LOCK_FILE) ?? true;
 
     this.go.enabled = config.get<boolean>(Configs.GO_ENABLED) ?? true;
     this.go.index = config.get<string>(Configs.GO_INDEX_SERVER_URL) || "https://proxy.golang.org";
-    this.go.unstableFilter = updateUnstableSettings(Configs.GO_UNSTABLE_FILTER, Configs.GO_UNSTABLE_OLD);
+    this.go.unstableFilter = migrateUnstableSettings(Configs.GO_UNSTABLE_FILTER, Configs.GO_UNSTABLE_OLD);
     this.go.ignoreLinePattern = config.get<string>(Configs.GO_IGNORE_LINE_PATTERN) || "";
     this.go.informPatchUpdates = config.get<boolean>(Configs.GO_INFORM_PATCH_UPDATES) ?? false;
 
     this.python.enabled = config.get<boolean>(Configs.PYTHON_ENABLED) ?? true;
     this.python.index = config.get<string>(Configs.PYTHON_INDEX_SERVER_URL) || "https://pypi.org/pypi";
-    this.python.unstableFilter = updateUnstableSettings(Configs.PYTHON_UNSTABLE_FILTER, Configs.PYTHON_UNSTABLE_OLD);
+    this.python.unstableFilter = migrateUnstableSettings(Configs.PYTHON_UNSTABLE_FILTER, Configs.PYTHON_UNSTABLE_OLD);
     this.python.ignoreLinePattern = config.get<string>(Configs.PYTHON_IGNORE_LINE_PATTERN) || "";
     this.python.informPatchUpdates = config.get<boolean>(Configs.PYTHON_INFORM_PATCH_UPDATES) ?? false;
     this.python.lockFileEnabled = config.get<boolean>(Configs.PYTHON_ENABLED_LOCK_FILE) ?? true;
@@ -238,7 +238,7 @@ export const Settings = {
   }
 };
 
-function updateUnstableSettings(newSettingKey: string , oldSettingKey: string): UnstableFilter {
+function migrateUnstableSettings(newSettingKey: string , oldSettingKey: string): UnstableFilter {
   const config = workspace.getConfiguration("dependi");
   const filter = config.get<string>(newSettingKey);
   if (Settings.version > "0.7.9") {
@@ -249,14 +249,5 @@ function updateUnstableSettings(newSettingKey: string , oldSettingKey: string): 
       return oldSetting ? UnstableFilter.Exclude : UnstableFilter.IncludeAlways;
     }
   }
-  switch (filter) {
-    case "Exclude":
-      return UnstableFilter.Exclude;
-    case "IncludeAlways":
-      return UnstableFilter.IncludeAlways;
-    case "IncludeIfUnstable":
-      return UnstableFilter.IncludeIfUnstable;
-    default:
-      return UnstableFilter.Exclude;
-  }
+  return UnstableFilter[filter as keyof typeof UnstableFilter] || UnstableFilter.Exclude;
 }

--- a/vscode/src/config.ts
+++ b/vscode/src/config.ts
@@ -7,34 +7,34 @@ const WORKBENCH_ACTIONS = "workbench.action.";
 export enum Configs {
   RUST_ENABLED = `rust.enabled`,
   RUST_INDEX_SERVER_URL = `rust.indexServerURL`,
-  RUST_IGNORE_UNSTABLES = `rust.excludeUnstableVersions`,
+  RUST_UNSTABLE_FILTER = `rust.unstableFilter`,
   RUST_IGNORE_LINE_PATTERN = `rust.ignoreLinePattern`,
   RUST_INFORM_PATCH_UPDATES = `rust.informPatchUpdates`,
   RUST_ENABLED_LOCK_FILE = `rust.lockFileEnabled`,
 
   NPM_ENABLED = `npm.enabled`,
   NPM_INDEX_SERVER_URL = `npm.indexServerURL`,
-  NPM_IGNORE_UNSTABLES = `npm.excludeUnstableVersions`,
+  NPM_UNSTABLE_FILTER = `npm.unstableFilter`,
   NPM_IGNORE_LINE_PATTERN = `npm.ignoreLinePattern`,
   NPM_INFORM_PATCH_UPDATES = `npm.informPatchUpdates`,
   NPM_ENABLED_LOCK_FILE = `npm.lockFileEnabled`,
 
   PHP_ENABLED = `php.enabled`,
   PHP_INDEX_SERVER_URL = `php.indexServerURL`,
-  PHP_IGNORE_UNSTABLES = `php.excludeUnstableVersions`,
+  PHP_UNSTABLE_FILTER = `php.unstableFilter`,
   PHP_IGNORE_LINE_PATTERN = `php.ignoreLinePattern`,
   PHP_INFORM_PATCH_UPDATES = `php.informPatchUpdates`,
   PHP_ENABLED_LOCK_FILE = `php.lockFileEnabled`,
 
   GO_ENABLED = `go.enabled`,
   GO_INDEX_SERVER_URL = `go.indexServerURL`,
-  GO_IGNORE_UNSTABLES = `go.excludeUnstableVersions`,
+  GO_UNSTABLE_FILTER = `go.unstableFilter`,
   GO_IGNORE_LINE_PATTERN = `go.ignoreLinePattern`,
   GO_INFORM_PATCH_UPDATES = `go.informPatchUpdates`,
 
   PYTHON_ENABLED = `python.enabled`,
   PYTHON_INDEX_SERVER_URL = `python.indexServerURL`,
-  PYTHON_IGNORE_UNSTABLES = `python.excludeUnstableVersions`,
+  PYTHON_UNSTABLE_FILTER = `python.unstableFilter`,
   PYTHON_IGNORE_LINE_PATTERN = `python.ignoreLinePattern`,
   PYTHON_INFORM_PATCH_UPDATES = `python.informPatchUpdates`,
   PYTHON_ENABLED_LOCK_FILE = `python.lockFileEnabled`,
@@ -82,7 +82,7 @@ export const Settings = {
   rust: {
     enabled: true,
     index: "",
-    ignoreUnstable: false,
+    unstableFilter: "exclude",
     ignoreLinePattern: "",
     informPatchUpdates: false,
     lockFileEnabled: true
@@ -91,7 +91,7 @@ export const Settings = {
   npm: {
     enabled: true,
     index: "",
-    ignoreUnstable: false,
+    unstableFilter: "exclude",
     ignoreLinePattern: "",
     informPatchUpdates: false,
     lockFileEnabled: true
@@ -99,7 +99,7 @@ export const Settings = {
   php: {
     enabled: true,
     index: "",
-    ignoreUnstable: false,
+    unstableFilter: "exclude",
     ignoreLinePattern: "",
     informPatchUpdates: false,
     lockFileEnabled: true
@@ -107,14 +107,14 @@ export const Settings = {
   go: {
     enabled: true,
     index: "",
-    ignoreUnstable: false,
+    unstableFilter: "exclude",
     ignoreLinePattern: "",
     informPatchUpdates: true
   },
   python: {
     enabled: true,
     index: "",
-    ignoreUnstable: false,
+    unstableFilter: "exclude",
     ignoreLinePattern: "",
     informPatchUpdates: false,
     lockFileEnabled: true
@@ -161,34 +161,34 @@ export const Settings = {
     // fill in the settings
     this.rust.enabled = config.get<boolean>(Configs.RUST_ENABLED) ?? true;
     this.rust.index = config.get<string>(Configs.RUST_INDEX_SERVER_URL) || "https://index.crates.io";
-    this.rust.ignoreUnstable = config.get<boolean>(Configs.RUST_IGNORE_UNSTABLES) ?? true;
+    this.rust.unstableFilter = config.get<string>(Configs.RUST_UNSTABLE_FILTER) ?? "exclude";
     this.rust.ignoreLinePattern = config.get<string>(Configs.RUST_IGNORE_LINE_PATTERN) || "";
     this.rust.informPatchUpdates = config.get<boolean>(Configs.RUST_INFORM_PATCH_UPDATES) ?? false;
     this.rust.lockFileEnabled = config.get<boolean>(Configs.RUST_ENABLED_LOCK_FILE) ?? true;
 
     this.npm.enabled = config.get<boolean>(Configs.NPM_ENABLED) ?? true;
     this.npm.index = config.get<string>(Configs.NPM_INDEX_SERVER_URL) || "https://registry.npmjs.org";
-    this.npm.ignoreUnstable = config.get<boolean>(Configs.NPM_IGNORE_UNSTABLES) ?? true;
+    this.npm.unstableFilter = config.get<string>(Configs.NPM_UNSTABLE_FILTER) ?? "exclude";
     this.npm.ignoreLinePattern = config.get<string>(Configs.NPM_IGNORE_LINE_PATTERN) || "";
     this.npm.informPatchUpdates = config.get<boolean>(Configs.NPM_INFORM_PATCH_UPDATES) ?? false;
     this.npm.lockFileEnabled = config.get<boolean>(Configs.NPM_ENABLED_LOCK_FILE) ?? true;
 
     this.php.enabled = config.get<boolean>(Configs.PHP_ENABLED) ?? true;
     this.php.index = config.get<string>(Configs.PHP_INDEX_SERVER_URL) || "https://repo.packagist.org";
-    this.php.ignoreUnstable = config.get<boolean>(Configs.PHP_IGNORE_UNSTABLES) ?? true;
+    this.php.unstableFilter = config.get<string>(Configs.PHP_UNSTABLE_FILTER) ?? "exclude";
     this.php.ignoreLinePattern = config.get<string>(Configs.PHP_IGNORE_LINE_PATTERN) || "";
     this.php.informPatchUpdates = config.get<boolean>(Configs.PHP_INFORM_PATCH_UPDATES) ?? false;
     this.php.lockFileEnabled = config.get<boolean>(Configs.PHP_ENABLED_LOCK_FILE) ?? true;
 
     this.go.enabled = config.get<boolean>(Configs.GO_ENABLED) ?? true;
     this.go.index = config.get<string>(Configs.GO_INDEX_SERVER_URL) || "https://proxy.golang.org";
-    this.go.ignoreUnstable = config.get<boolean>(Configs.GO_IGNORE_UNSTABLES) ?? true;
+    this.go.unstableFilter = config.get<string>(Configs.GO_UNSTABLE_FILTER) ?? "exclude";
     this.go.ignoreLinePattern = config.get<string>(Configs.GO_IGNORE_LINE_PATTERN) || "";
     this.go.informPatchUpdates = config.get<boolean>(Configs.GO_INFORM_PATCH_UPDATES) ?? false;
 
     this.python.enabled = config.get<boolean>(Configs.PYTHON_ENABLED) ?? true;
     this.python.index = config.get<string>(Configs.PYTHON_INDEX_SERVER_URL) || "https://pypi.org/pypi";
-    this.python.ignoreUnstable = config.get<boolean>(Configs.PYTHON_IGNORE_UNSTABLES) ?? true;
+    this.python.unstableFilter = config.get<string>(Configs.PYTHON_UNSTABLE_FILTER) ?? "exclude";
     this.python.ignoreLinePattern = config.get<string>(Configs.PYTHON_IGNORE_LINE_PATTERN) || "";
     this.python.informPatchUpdates = config.get<boolean>(Configs.PYTHON_INFORM_PATCH_UPDATES) ?? false;
     this.python.lockFileEnabled = config.get<boolean>(Configs.PYTHON_ENABLED_LOCK_FILE) ?? true;
@@ -221,6 +221,7 @@ export const Settings = {
       //TODO: traverse all keys and update the settings if they are changed
       console.debug("Config changed");
       this.load();
+      const x = Settings.npm.unstableFilter
     }
   }
 };

--- a/vscode/src/core/fetchers/CratesFetcher.ts
+++ b/vscode/src/core/fetchers/CratesFetcher.ts
@@ -15,7 +15,7 @@ export class CratesFetcher extends Fetcher {
       return versions(dep.item.key)
         .then((crate) => {
           const versions = crate.versions
-            .filter((i: string) => i !== "" && i !== undefined && !base.checkPreRelease(Settings.rust.ignoreUnstable, i))
+            .filter((i: string) => i !== "" && i !== undefined && !base.checkUnstables(Settings.rust.unstableFilter, i, dep.item.value!))
             .sort(compareVersions)
             .reverse();
 

--- a/vscode/src/core/fetchers/DependiFetcher.ts
+++ b/vscode/src/core/fetchers/DependiFetcher.ts
@@ -12,27 +12,27 @@ import { Fetcher } from "./fetcher";
 export class DependiFetcher extends Fetcher {
 
   async versions(dependencies: Dependency[]): Promise<Dependency[]> {
-    let ignoreUnstable = false;
+    let ignoreUnstable = "exclude";
     switch (CurrentLanguage) {
       case Language.Python:
-        ignoreUnstable = Settings.python.ignoreUnstable;
+        ignoreUnstable = Settings.python.unstableFilter;
         break;
       case Language.JS:
-        ignoreUnstable = Settings.npm.ignoreUnstable;
+        ignoreUnstable = Settings.npm.unstableFilter;
         break;
       case Language.Golang:
-        ignoreUnstable = Settings.go.ignoreUnstable;
+        ignoreUnstable = Settings.go.unstableFilter;
         break;
       case Language.PHP:
-        ignoreUnstable = Settings.php.ignoreUnstable;
+        ignoreUnstable = Settings.php.unstableFilter;
         break;
       case Language.Rust:
-        ignoreUnstable = Settings.rust.ignoreUnstable;
+        ignoreUnstable = Settings.rust.unstableFilter;
         break;
     }
     const req: VersionsReq = {
       Language: CurrentLanguage,
-      Packages: dependencies.map((d) => d.item.key),
+      Packages: dependencies.map((d) => d.item),
       Dependencies: dependencies,
       IgnoreUnstables: ignoreUnstable,
       VulnerabilityCheck: Settings.vulnerability.enabled,

--- a/vscode/src/core/fetchers/DependiFetcher.ts
+++ b/vscode/src/core/fetchers/DependiFetcher.ts
@@ -1,5 +1,5 @@
 import { Indexes, VersionsReq } from "../../api/indexes/dependi/indexes";
-import { Settings } from "../../config";
+import { Settings, UnstableFilter } from "../../config";
 import { Logger } from "../../extension";
 import compareVersions from "../../semver/compareVersions";
 import Dependency from "../Dependency";
@@ -12,29 +12,29 @@ import { Fetcher } from "./fetcher";
 export class DependiFetcher extends Fetcher {
 
   async versions(dependencies: Dependency[]): Promise<Dependency[]> {
-    let ignoreUnstable = "exclude";
+    let unstableFilter = UnstableFilter.Exclude;
     switch (CurrentLanguage) {
       case Language.Python:
-        ignoreUnstable = Settings.python.unstableFilter;
+        unstableFilter = Settings.python.unstableFilter;
         break;
       case Language.JS:
-        ignoreUnstable = Settings.npm.unstableFilter;
+        unstableFilter = Settings.npm.unstableFilter;
         break;
       case Language.Golang:
-        ignoreUnstable = Settings.go.unstableFilter;
+        unstableFilter = Settings.go.unstableFilter;
         break;
       case Language.PHP:
-        ignoreUnstable = Settings.php.unstableFilter;
+        unstableFilter = Settings.php.unstableFilter;
         break;
       case Language.Rust:
-        ignoreUnstable = Settings.rust.unstableFilter;
+        unstableFilter = Settings.rust.unstableFilter;
         break;
     }
     const req: VersionsReq = {
       Language: CurrentLanguage,
       Packages: dependencies.map((d) => d.item),
       Dependencies: dependencies,
-      IgnoreUnstables: ignoreUnstable,
+      IgnoreUnstables: unstableFilter,
       VulnerabilityCheck: Settings.vulnerability.enabled,
       GhsaCheck: Settings.vulnerability.ghsa
     };

--- a/vscode/src/core/fetchers/GoProxyFetcher.ts
+++ b/vscode/src/core/fetchers/GoProxyFetcher.ts
@@ -13,7 +13,7 @@ export class GoProxyFetcher extends Fetcher {
     return async function (dep: Dependency): Promise<Dependency> {
       return versions(dep.item.key).then((mod) => {
         const versions = mod.versions
-          .filter((i: string) => i !== "" && i !== undefined && !base.checkPreRelease(Settings.go.ignoreUnstable, i))
+          .filter((i: string) => i !== "" && i !== undefined && !base.checkUnstables(Settings.go.unstableFilter, i, dep.item.value!))
           .sort(compareVersions).reverse();
         dep.versions = versions;
         return dep;

--- a/vscode/src/core/fetchers/NpmFetcher.ts
+++ b/vscode/src/core/fetchers/NpmFetcher.ts
@@ -14,7 +14,7 @@ export class NpmFetcher extends Fetcher {
       const checkVersion = isLatest ? versions(dep.item.key, dep.item.value) : versions(dep.item.key);
       return checkVersion.then((mod) => {
         const versions = mod.versions
-          .filter((i: string) => i !== "" && i !== undefined && !base.checkPreRelease(Settings.npm.ignoreUnstable, i))
+          .filter((i: string) => i !== "" && i !== undefined && !base.checkUnstables(Settings.npm.unstableFilter, i, dep.item.value!))
           .sort(compareVersions).reverse();
         dep.versions = versions;
         dep.item.value = dep.item.value === "latest" ? mod.latestVersion : dep.item.value;

--- a/vscode/src/core/fetchers/PackagistFetcher.ts
+++ b/vscode/src/core/fetchers/PackagistFetcher.ts
@@ -14,7 +14,7 @@ export class PackagistFetcher extends Fetcher {
       const checkVersion = isLatest ? versions(dep.item.key) : versions(dep.item.key);
       return checkVersion.then((mod: any) => {
         const versions = mod.versions
-          .filter((i: string) => i !== "" && i !== undefined && !base.checkPreRelease(Settings.php.ignoreUnstable, i))
+          .filter((i: string) => i !== "" && i !== undefined && !base.checkUnstables(Settings.php.unstableFilter, i, dep.item.value!))
           .sort(compareVersions)
           .reverse();
         dep.versions = versions;

--- a/vscode/src/core/fetchers/PypiFetcher.ts
+++ b/vscode/src/core/fetchers/PypiFetcher.ts
@@ -1,6 +1,6 @@
 import { DependencyInfo } from "../../api/DepencencyInfo";
 import { versions } from "../../api/indexes/pypi";
-import { Settings } from "../../config";
+import { Settings, UnstableFilter } from "../../config";
 import compareVersions from "../../semver/compareVersions";
 import { fetcherCatch } from "../../utils/errors";
 import Dependency from "../Dependency";
@@ -20,9 +20,9 @@ export class PypiFetcher extends Fetcher {
     };
   }
 
-  checkUnstables(unstableFilter: string, version: string, currentVersion: string): boolean {
-    if (unstableFilter === "includeAlways") return false;
-    if (unstableFilter === "includeIfUnstable" && checkPreRelease(currentVersion)) return false;
+  checkUnstables(unstableFilter: UnstableFilter, version: string, currentVersion: string): boolean {
+    if (unstableFilter === UnstableFilter.IncludeAlways) return false;
+    if (unstableFilter === UnstableFilter.IncludeIfUnstable && checkPreRelease(currentVersion)) return false;
     return checkPreRelease(version);
   }
 

--- a/vscode/src/core/fetchers/PypiFetcher.ts
+++ b/vscode/src/core/fetchers/PypiFetcher.ts
@@ -20,28 +20,16 @@ export class PypiFetcher extends Fetcher {
     };
   }
 
-  checkPreRelease(ignoreUnstable: boolean, version: string): boolean {
-    if (!ignoreUnstable) return false;
-    // alpha and beta regexes for python
-    const aORb = /\..*a|b.*/;
-    return (
-      version.indexOf(".alpha") !== -1 ||
-      version.indexOf(".beta") !== -1 ||
-      version.indexOf(".rc") !== -1 ||
-      version.indexOf(".SNAPSHOT") !== -1 ||
-      version.indexOf(".dev") !== -1 ||
-      version.indexOf(".preview") !== -1 ||
-      version.indexOf(".experimental") !== -1 ||
-      version.indexOf(".canary") !== -1 ||
-      version.indexOf(".pre") !== -1 ||
-      version.indexOf("rc") !== -1 ||
-      aORb.test(version)
-    );
+  checkUnstables(unstableFilter: string, version: string, currentVersion: string): boolean {
+    if (unstableFilter === "includeAlways") return false;
+    if (unstableFilter === "includeIfUnstable" && checkPreRelease(currentVersion)) return false;
+    return checkPreRelease(version);
   }
+
   mapVersions(di: DependencyInfo, dep: Dependency): Dependency {
     const versions = di
       .versions!
-      .filter((i: string) => i !== "" && i !== undefined && !this.checkPreRelease(Settings.python.ignoreUnstable, i))
+      .filter((i: string) => i !== "" && i !== undefined && !this.checkUnstables(Settings.python.unstableFilter, i, dep.item.value!))
       .sort(compareVersions)
       .reverse();
     // if (dep) {
@@ -59,3 +47,19 @@ export class PypiFetcher extends Fetcher {
   }
 }
 
+function checkPreRelease(version: string): boolean {
+  const aORb = /\..*a|b.*/;
+  return (
+    version.indexOf(".alpha") !== -1 ||
+    version.indexOf(".beta") !== -1 ||
+    version.indexOf(".rc") !== -1 ||
+    version.indexOf(".SNAPSHOT") !== -1 ||
+    version.indexOf(".dev") !== -1 ||
+    version.indexOf(".preview") !== -1 ||
+    version.indexOf(".experimental") !== -1 ||
+    version.indexOf(".canary") !== -1 ||
+    version.indexOf(".pre") !== -1 ||
+    version.indexOf("rc") !== -1 ||
+    aORb.test(version)
+  );
+}

--- a/vscode/src/core/fetchers/fetcher.ts
+++ b/vscode/src/core/fetchers/fetcher.ts
@@ -1,4 +1,5 @@
 import { queryMultiplePackageVulns } from "../../api/osv/vulnerability-service";
+import { UnstableFilter } from "../../config";
 import { openSettingsDialog } from "../../ui/dialogs";
 import { StatusBar } from "../../ui/status-bar";
 import Dependency from "../Dependency";
@@ -73,9 +74,9 @@ export abstract class Fetcher {
     return Promise.all(responses);
   }
 
-  checkUnstables(unstableFilter: string, version: string, currentVersion: string): boolean {
-    if (unstableFilter === "includeAlways") return false;
-    if (unstableFilter === "includeIfUnstable" && checkPreRelease(currentVersion)) return false;
+  checkUnstables(unstableFilter: UnstableFilter, version: string, currentVersion: string): boolean {
+    if (unstableFilter === UnstableFilter.IncludeAlways) return false;
+    if (unstableFilter === UnstableFilter.IncludeIfUnstable && checkPreRelease(currentVersion)) return false;
     return checkPreRelease(version);
   }
 }

--- a/vscode/src/core/fetchers/fetcher.ts
+++ b/vscode/src/core/fetchers/fetcher.ts
@@ -73,19 +73,10 @@ export abstract class Fetcher {
     return Promise.all(responses);
   }
 
-  checkPreRelease(ignoreUnstable: boolean, version: string): boolean {
-    if (!ignoreUnstable) return false;
-    return (
-      version.indexOf("-alpha") !== -1 ||
-      version.indexOf("-beta") !== -1 ||
-      version.indexOf("-rc") !== -1 ||
-      version.indexOf("-SNAPSHOT") !== -1 ||
-      version.indexOf("-dev") !== -1 ||
-      version.indexOf("-preview") !== -1 ||
-      version.indexOf("-experimental") !== -1 ||
-      version.indexOf("-canary") !== -1 ||
-      version.indexOf("-pre") !== -1
-    );
+  checkUnstables(unstableFilter: string, version: string, currentVersion: string): boolean {
+    if (unstableFilter === "includeAlways") return false;
+    if (unstableFilter === "includeIfUnstable" && checkPreRelease(currentVersion)) return false;
+    return checkPreRelease(version);
   }
 }
 function chunkDataArray(data: Dependency[], chunkSize: number) {
@@ -110,4 +101,20 @@ function chunkDataArray(data: Dependency[], chunkSize: number) {
     chunkedData.push(currentChunk);
   }
   return chunkedData;
+}
+
+function checkPreRelease(version: string): boolean {
+  return (
+    version.indexOf("-alpha") !== -1 ||
+    version.indexOf("-beta") !== -1 ||
+    version.indexOf("-rc") !== -1 ||
+    version.indexOf("-SNAPSHOT") !== -1 ||
+    version.indexOf("-dev") !== -1 ||
+    version.indexOf("-preview") !== -1 ||
+    version.indexOf("-experimental") !== -1 ||
+    version.indexOf("-canary") !== -1 ||
+    version.indexOf("-pre") !== -1 ||
+    version.indexOf("-next") !== -1 ||
+    version.indexOf("-nightly") !== -1
+  );
 }


### PR DESCRIPTION

###  Description:
- Replaced the `ignoreUnstables` setting with `unstableFilter` across all supported languages.
  - New setting options:
    - `exclude`: Exclude unstable versions.
    - `includeAlways`: Always include unstable versions.
    - `includeIfUnstable`: Include only if the current version is already unstable.
- Updated README and extension descriptions to reflect these changes.