### PR TITLE
Fix dependency version display for Python projects

### DIFF
--- a/vscode/src/semver/semverUtils.ts
+++ b/vscode/src/semver/semverUtils.ts
@@ -7,6 +7,7 @@ export function checkVersion(version: string = "0.0.0", versions: string[], lock
   let v = version;
 
   v = versionToSemver(v);
+  lockedAt = lockedAt && versionToSemver(lockedAt);
   version = versionToSemver(version);
   versions = versions.map(versionToSemver);
   
@@ -50,7 +51,7 @@ export function checkVersion(version: string = "0.0.0", versions: string[], lock
   return [satisfies(max, v), pathUpdated, maxSatisfying(versions, v)];
 }
 
-function versionToSemver(version: string): string {
+export function versionToSemver(version: string): string {
   if (CurrentLanguage === Language.Python) {
     return convertPythonVersionToSemver(version);
   }
@@ -89,7 +90,7 @@ function convertPythonVersion(version: string): string {
       .replace(/c(\d+)/, '-c.$1')
 }
 
-export function convertPythonVersionToSemver(version: string): string {
+function convertPythonVersionToSemver(version: string): string {
   const v = convertPythonVersion(version);
   const pattern = /^(\d+)\.(\d+)(?:\.(\d+))?([-a-zA-Z0-9.]+)?$/;
   const match = v.match(pattern);

--- a/vscode/src/ui/decoration.ts
+++ b/vscode/src/ui/decoration.ts
@@ -14,7 +14,7 @@ import { CommandData } from "../commands/replacers";
 import { Configs } from "../config";
 import Item from "../core/Item";
 import { CurrentLanguage, Language } from "../core/Language";
-import { checkVersion, convertPythonVersionToSemver } from "../semver/semverUtils";
+import { checkVersion, versionToSemver } from "../semver/semverUtils";
 import DecorationPreferences from "./pref";
 
 type DecorationType = "COMP" | "PATCH" | "INCOMP" | "ERROR";
@@ -46,10 +46,10 @@ export default function decoration(
     markdown.appendMarkdown("\n");
     // Ignore empty strings
     error_parts.filter(s => s).forEach(part => {
-      markdown.appendMarkdown("* ");
-      markdown.appendText(part.trim()); // Gets rid of Markdown-breaking spaces, then append text safely escaped.
-      markdown.appendMarkdown("\n"); // Put the newlines back
-    });
+        markdown.appendMarkdown("* ");
+        markdown.appendText(part.trim()); // Gets rid of Markdown-breaking spaces, then append text safely escaped.
+        markdown.appendMarkdown("\n"); // Put the newlines back
+      });
     return markdown;
   };
   let hoverMessage = new MarkdownString();
@@ -84,7 +84,7 @@ export default function decoration(
       editor.document.save();
     }
     if (CurrentLanguage === Language.Python) {
-      version = convertPythonVersionToSemver(version!);
+      version = versionToSemver(version!);
     }
     if (!validRange(version)) {
       type = "ERROR";
@@ -212,7 +212,7 @@ function appendVersions(hoverMessage: MarkdownString, versions: string[], item: 
       startLine: item.range.start.line,
     };
 
-    const isCurrent = version === maxSatisfying;
+    const isCurrent = versionToSemver(version) === maxSatisfying;
     const encoded = encodeURI(JSON.stringify(data));
     const docs = (i === 0 || isCurrent) ? (' ' + getDocsLink(lang, item.key, version)) : "";
     const vulnText = v?.length ? decorationPreferences.vulnText.replace("${count}", `${v?.length}`) : "";


### PR DESCRIPTION
This PR fixes inaccurate version display for Python dependencies that don’t follow standard semver formatting. Python projects can now show dependency status accurately, even with non-semver version formats.

closes #161 