### PR TITLE
feat: Add support for requirements-dev.txt file

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -75,17 +75,17 @@
     "menus": {
       "editor/title": [
         {
-          "when": "dependi.hasLockFile && resourceFilename != 'go.mod' && resourceFilename != 'requirements.txt'",
+          "when": "dependi.hasLockFile && resourceFilename != 'go.mod' && resourceFilename != 'requirements.txt' && resourceFilename != 'requirements-dev.txt'",
           "command": "dependi.commands.lockFileParsed",
           "group": "navigation"
         },
         {
-          "when": "!dependi.hasLockFile && dependi.isLockFileEnabled && resourceFilename in dependi.supportedFiles && resourceFilename != 'go.mod' && resourceFilename != 'requirements.txt'",
+          "when": "!dependi.hasLockFile && dependi.isLockFileEnabled && resourceFilename in dependi.supportedFiles && resourceFilename != 'go.mod' && resourceFilename != 'requirements.txt' && resourceFilename != 'requirements-dev.txt'",
           "command": "dependi.commands.disableLockFileParsing",
           "group": "navigation"
         },
         {
-          "when": "!dependi.hasLockFile && !dependi.isLockFileEnabled && resourceFilename in dependi.supportedFiles && resourceFilename != 'go.mod' && resourceFilename != 'requirements.txt'",
+          "when": "!dependi.hasLockFile && !dependi.isLockFileEnabled && resourceFilename in dependi.supportedFiles && resourceFilename != 'go.mod' && resourceFilename != 'requirements.txt' && resourceFilename != 'requirements-dev.txt'",
           "command": "dependi.commands.enableLockFileParsing",
           "group": "navigation"
         },

--- a/vscode/src/core/Language.ts
+++ b/vscode/src/core/Language.ts
@@ -37,6 +37,7 @@ export function setLanguage(file?: string) {
         case "package.json":
             return setLanguageConfig(Language.JS, "npm", filename, OCVEnvironment.Npm, Settings.npm.lockFileEnabled);
         case "requirements.txt":
+        case "requirements-dev.txt":
             return setLanguageConfig(Language.Python, "python", filename, OCVEnvironment.Pypi);
         case "composer.json":
             return setLanguageConfig(Language.PHP, "php", filename, OCVEnvironment.Packagist, Settings.php.lockFileEnabled);

--- a/vscode/src/core/parsers/PypiParser.ts
+++ b/vscode/src/core/parsers/PypiParser.ts
@@ -20,7 +20,7 @@ export class PypiParser {
       if (shouldIgnoreLine(line, Settings.python.ignoreLinePattern, ["#", "-", "."])) {
         continue;
       }
-      if (state.bypass) {
+      if (state.bypass || !line.text.includes("=")) {
         continue;
       }
       let item = parseDependencyLine(line);

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -98,6 +98,7 @@ export function activate(context: ExtensionContext) {
     "package.json",
     "composer.json",
     "requirements.txt",
+    "requirements-dev.txt",
     "pyproject.toml",
   ]);
 


### PR DESCRIPTION
This PR enhances the extension by adding support for requirements-dev.txt files, allowing the display and checking of development dependencies in Python projects. This update provides a more comprehensive dependency management experience for users working with separate development dependencies.

closes #162 