### PR TITLE
chore: Ignore 'requires-python' key in pyproject parser

### DIFF
--- a/vscode/src/core/parsers/PyProjectParser.ts
+++ b/vscode/src/core/parsers/PyProjectParser.ts
@@ -11,7 +11,7 @@ export class PyProjectParser extends TomlParser {
     if (!state.currentItem.isValid()) {
       return;
     }
-    const ingoreKey = ["python"];
+    const ingoreKey = ["python", "requires-python"];
     if (ingoreKey.includes(state.currentItem.key)) {
       return;
     }


### PR DESCRIPTION
This PR updates the pyproject parser to ignore the requires-python key, focusing parsing on dependencies while omitting Python version requirements. This ensures streamlined parsing and reduces unnecessary checks for version constraints.

closes #164 