### PR TITLE
fix: exclude Git URL dependency handling

### DIFF
--- a/vscode/changelog.md
+++ b/vscode/changelog.md
@@ -16,6 +16,8 @@ All notable changes to the "dependi" extension will be documented in this file.
 
 - Reordered button groups for better visibility control and hiding less critical buttons when space is limited.[Issue #177](https://github.com/filllabs/dependi/issues/177)
 
+- Excluded Git URL dependencies handling for future consideration.
+
 ## [v0.7.12]((https://github.com/filllabs/dependi/compare/v0.7.11...v0.7.12))
 
 ### Improvements

--- a/vscode/src/core/parsers/TomlParser.ts
+++ b/vscode/src/core/parsers/TomlParser.ts
@@ -156,7 +156,7 @@ export class TomlParser implements Parser {
       .trim()
       .replace(/^"|"$|'/g, "");
 
-    if (isBoolean(item.value) || item.value.includes("path")) {
+    if (isBoolean(item.value) || containsIgnoreKeys(item.value)) {
       return undefined;
     }
     if (line.indexOf("{") > -1) {
@@ -308,4 +308,9 @@ function parseLockFile(item: Item[]): Item[] {
     console.error(err);
   }
   return item;
+}
+
+function containsIgnoreKeys(key: string) {
+  const ignoreKeys = ["git", "path" ];
+  return ignoreKeys.some((k) => key.includes(k));
 }


### PR DESCRIPTION
Excluded Git URL dependencies handling for future consideration.
