### PR TITLE
feat: add option to silence informational update messages

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -118,6 +118,10 @@ While Dependi works out-of-the-box without any configuration, we also offer a fe
 - `dependi.decoration.error.style`: Style for error version decorations.
 - `dependi.decoration.vulnerability.template`: Decoration for vulnerable package versions.
 
+### Extras
+
+- `dependi.extras.silenceUpdateMessages`: This setting hides informational update messages when enabled (true).
+
 ### Cargo.toml, go.mod, package.json and requirements.txt
 
 - `# dependi: disable-check`: Disable version check for this specific dependency.

--- a/vscode/changelog.md
+++ b/vscode/changelog.md
@@ -10,7 +10,9 @@ All notable changes to the "dependi" extension will be documented in this file.
 
 - Added setting to treat non-registry versions as up-to-date for all languages.
 
-- Support a pixi.toml configuration file in a Python project [Issues #179](https://github.com/filllabs/dependi/issues/179)
+- Support a pixi.toml configuration file in a Python project [Issue #179](https://github.com/filllabs/dependi/issues/179)
+
+- Added `dependi.extras.silenceUpdateMessages` to disable informational update messages when enabled. [Issue #193](https://github.com/filllabs/dependi/issues/193)
 
 ### Bug Fixes
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -863,6 +863,18 @@
             "order": 20
           }
         }
+      },  
+      {
+        "title": "Extras",
+        "properties": {
+          "dependi.extras.silenceUpdateMessages": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": false,
+            "description": "Enable to silence informational update messages.",
+            "order": 1
+          }
+        }
       }
     ]
   },

--- a/vscode/src/config.ts
+++ b/vscode/src/config.ts
@@ -82,6 +82,9 @@ export enum Configs {
   DISABLE_LOCK_FILE_PARSING = `${DEPENDI}commands.disableLockFileParsing`,
   LOCK_FILE_PARSED = `${DEPENDI}commands.lockFileParsed`,
 
+  // Extras
+  SILENCE_UPDATE_MESSAGES = `extras.silenceUpdateMessages`,
+
 
   //Storage
   DEVICE_ID = `${DEPENDI}deviceID`,
@@ -176,6 +179,9 @@ export const Settings = {
       template: ""
     }
   },
+  extras: {
+    silenceUpdateMessages: false
+  },
 
   load: function () {
     const config = workspace.getConfiguration("dependi");
@@ -228,9 +234,6 @@ export const Settings = {
     this.api.key = config.get<string>(Configs.INDEX_SERVER_API_KEY) || "";
     this.api.url = config.get<string>(Configs.INDEX_SERVER_URL) || "https://index.dependi.io";
 
-
-
-
     this.decorator.position = config.get<DecorationPosition>(Configs.DECORATOR_POSITION) || "after";
     this.decorator.error.template = config.get<string>(Configs.ERROR_DECORATOR) ?? "❗️❗️❗️";
     this.decorator.error.css = config.get<DecorationInstanceRenderOptions>(Configs.ERROR_DECORATOR_CSS) || {};
@@ -241,6 +244,8 @@ export const Settings = {
     this.decorator.compatible.template = config.get<string>(Configs.COMPATIBLE_DECORATOR) ?? "✅";
     this.decorator.compatible.css = config.get<DecorationInstanceRenderOptions>(Configs.COMPATIBLE_DECORATOR_CSS) || {};
     this.decorator.vulnerability.template = config.get<string>(Configs.VULNERABILITY_DECORATOR) ?? "🚨 ${count}";
+
+    this.extras.silenceUpdateMessages = config.get<boolean>(Configs.SILENCE_UPDATE_MESSAGES) ?? false;
     console.debug("Settings loaded", this);
   },
   onChange: function (e: ConfigurationChangeEvent) {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -129,17 +129,19 @@ async function configure(context: ExtensionContext) {
     await lt.setShownVersion(Settings.version);
   } else if (lt.shouldShowWelcomePage(context.extension.packageJSON.version)) {
     Logger.appendLine("Updated version");
-    window
-      .showInformationMessage(
-        "Dependi has been updated to a new version. See the CHANGELOG!",
-        "Show Changelog",
-        "Dismiss"
-      )
-      .then((selection) => {
-        if (selection === "Show Changelog") {
-          ChangelogPanel.render(context);
-        }
-      });
+    if (!Settings.extras.silenceUpdateMessages) {
+      window
+        .showInformationMessage(
+          "Dependi has been updated to a new version. See the CHANGELOG!",
+          "Show Changelog",
+          "Dismiss"
+        )
+        .then((selection) => {
+          if (selection === "Show Changelog") {
+            ChangelogPanel.render(context);
+          }
+        });
+    }
     await lt.setShownVersion(context.extension.packageJSON.version);
   }
 }


### PR DESCRIPTION
Added `dependi.extras.silenceUpdateMessages` to hide informational update messages when enabled.