### PR TITLE
Fix Inline Comment Parsing in Cargo.toml Dependencies

### DIFF
--- a/vscode/changelog.md
+++ b/vscode/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "dependi" extension will be documented in this file.
 
+## [v0.7.14]((https://github.com/filllabs/dependi/compare/v0.7.13...v0.7.14))
+
+### Bug Fixes
+
+- Fixed inline comment parsing in `Cargo.toml` dependencies to extract package names correctly. [Issue #204](https://github.com/filllabs/dependi/issues/204)
+
 ## [v0.7.13]((https://github.com/filllabs/dependi/compare/v0.7.12...v0.7.13))
 
 ### Improvements

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependi",
-  "version": "0.7.8",
+  "version": "0.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dependi",
-      "version": "0.7.8",
+      "version": "0.7.13",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@neuralegion/cvss": "1.2.2",

--- a/vscode/src/core/parsers/TomlParser.ts
+++ b/vscode/src/core/parsers/TomlParser.ts
@@ -58,10 +58,14 @@ export class TomlParser implements Parser {
           state.isSubTable = false;
           state.isSingle = true;
           state.currentItem = new Item();
+          let cleanText = line.text;
+          if (cleanText.includes("#")) {
+            cleanText = cleanText.substring(0, cleanText.indexOf("#")).trim();
+          }
           // crate name is the last part of the table name
-          state.currentItem.key = line.text.substring(
-            line.text.lastIndexOf(".") + 1,
-            line.text.indexOf("]")
+          state.currentItem.key = cleanText.substring(
+            cleanText.lastIndexOf(".") + 1,
+            cleanText.indexOf("]")
           );
         } else {
           state.isMultipleDepTable = false;
@@ -172,7 +176,7 @@ export class TomlParser implements Parser {
 
   isSubTable(line: string, state: State): boolean {
     return false;
-  } 
+  }
 }
 
 export function parseVersion(line: string, item: Item) {
@@ -300,7 +304,7 @@ function parseLockFile(item: Item[]): Item[] {
       const fileContent = fs.readFileSync(lockFilePath, "utf8");
       const LockFileParser = new TomlLockFileParser();
       item = LockFileParser.parse(fileContent, item);
-      commands.executeCommand("setContext", "dependi.hasLockFile", true); 
+      commands.executeCommand("setContext", "dependi.hasLockFile", true);
     } else {
       commands.executeCommand("setContext", "dependi.hasLockFile", false);
     }
@@ -311,6 +315,6 @@ function parseLockFile(item: Item[]): Item[] {
 }
 
 function containsIgnoreKeys(key: string) {
-  const ignoreKeys = ["git", "path" ];
+  const ignoreKeys = ["git", "path"];
   return ignoreKeys.some((k) => key.includes(k));
 }


### PR DESCRIPTION

**Description:**
This PR addresses a parsing issue in the `TomlParser` where inline comments in `Cargo.toml` dependency tables caused incorrect extraction of package names. The fix ensures that package names are correctly parsed, even when inline comments are present.

**Changes:**
- Updated `TomlParser` to handle inline comments in dependency tables.
- Ensured proper extraction of package names without including comment text.

**Issue Reference:**
- Resolves [Issue #204](https://github.com/filllabs/dependi/issues/204)

**Testing:**
- Verified the fix with test cases containing inline comments in `Cargo.toml` dependency tables.
- Ensured no regressions in existing functionality.