### PR TITLE
Fix TOML Parser Dependency Index Calculation

### DIFF
--- a/vscode/changelog.md
+++ b/vscode/changelog.md
@@ -8,6 +8,8 @@ All notable changes to the "dependi" extension will be documented in this file.
 
 - Fixed inline comment parsing in `Cargo.toml` dependencies to extract package names correctly. [Issue #204](https://github.com/filllabs/dependi/issues/204)
 
+- Fixed an issue with incorrect calculation of the version start position, ensuring accurate parsing.[Issue #220](https://github.com/filllabs/dependi/issues/205)
+
 ## [v0.7.13]((https://github.com/filllabs/dependi/compare/v0.7.12...v0.7.13))
 
 ### Improvements

--- a/vscode/src/core/parsers/TomlParser.ts
+++ b/vscode/src/core/parsers/TomlParser.ts
@@ -169,7 +169,7 @@ export class TomlParser implements Parser {
       parseVersion(line, item);
       return item.start > -1 ? item : undefined;
     }
-    item.start = line.indexOf(item.value);
+    item.start = line.indexOf(item.value, eqIndex);
     item.end = item.start + item.value.length;
     return item.start > -1 ? item : undefined;
   }


### PR DESCRIPTION
**Description:**
This PR fixes a bug in the `TomlParser` where the `item.start` index was miscalculated, improving dependency parsing accuracy in `Cargo.toml` files.

**Changes:**
- Corrected `item.start` index calculation using `eqIndex`.

**Impact:**
- Ensures accurate dependency extraction in `Cargo.toml`.

**Related Issue:** [#220](https://github.com/filllabs/dependi/issues/220)