### PR TITLE
Fix: Correct parsing of `~=` version constraints in `requirements.txt`

### DIFF
--- a/vscode/changelog.md
+++ b/vscode/changelog.md
@@ -12,9 +12,11 @@ All notable changes to the "dependi" extension will be documented in this file.
 
 - Fixed inline comment parsing in `Cargo.toml` dependencies to extract package names correctly. [Issue #204](https://github.com/filllabs/dependi/issues/204)
 
-## [v0.7.13](https://github.com/filllabs/dependi/compare/v0.7.12...v0.7.13)
 - Fixed an issue with incorrect calculation of the version start position, ensuring accurate parsing.[Issue #220](https://github.com/filllabs/dependi/issues/205)
 
+- Fixed parsing of version constraints starting with `~=` in `requirements.txt` files.[Issue #218](https://github.com/filllabs/dependi/issues/218)
+
+## [v0.7.13](https://github.com/filllabs/dependi/compare/v0.7.12...v0.7.13)
 
 ### Improvements
 

--- a/vscode/src/core/parsers/PypiParser.ts
+++ b/vscode/src/core/parsers/PypiParser.ts
@@ -59,7 +59,8 @@ function parseDependencyLine(line: TextLine): Item {
   if (
     version.startsWith("==") ||
     version.startsWith(">=") ||
-    version.startsWith("<=")
+    version.startsWith("<=") ||
+    version.startsWith("~=")
   ) {
     startOfVersion += 2;
   }


### PR DESCRIPTION
#### Summary
This pull request addresses a bug in the parsing of version constraints in `requirements.txt` files. Specifically, it fixes the issue where version constraints starting with `~=` were not being correctly parsed.

#### Changes
- Updated the logic in the parser to handle `~=` version constraints in `requirements.txt` files.
- Adjusted the changelog to reflect this bug fix under version `0.7.14`.

#### Testing
- Verified the parsing of `requirements.txt` files with various version constraints, including `~=`.

#### Resolved Issues
- Resolves [#218](https://github.com/filllabs/dependi/issues/218)