### PR TITLE
Fix Parsing of Invalid Package Names in TOML Files

### DIFF
--- a/vscode/changelog.md
+++ b/vscode/changelog.md
@@ -16,6 +16,8 @@ All notable changes to the "dependi" extension will be documented in this file.
 
 - Fixed parsing of version constraints starting with `~=` in `requirements.txt` files.[Issue #218](https://github.com/filllabs/dependi/issues/218)
 
+- Fixed invalid package name handling in `Cargo.toml` for more accurate dependency parsing.[Issue #208](https://github.com/filllabs/dependi/issues/208)
+
 ## [v0.7.13](https://github.com/filllabs/dependi/compare/v0.7.12...v0.7.13)
 
 ### Improvements

--- a/vscode/src/core/parsers/TomlParser.ts
+++ b/vscode/src/core/parsers/TomlParser.ts
@@ -160,7 +160,11 @@ export class TomlParser implements Parser {
       .trim()
       .replace(/^"|"$|'/g, "");
 
-    if (isBoolean(item.value) || containsIgnoreKeys(item.value)) {
+    if (
+      isBoolean(item.value) ||
+      containsIgnoredKeywordsInValue(item.value) ||
+      containsIgnoredKeywordsInKey(item.key)
+    ) {
       return undefined;
     }
     if (line.indexOf("{") > -1) {
@@ -314,7 +318,12 @@ function parseLockFile(item: Item[]): Item[] {
   return item;
 }
 
-function containsIgnoreKeys(key: string) {
-  const ignoreKeys = ["git", "path"];
-  return ignoreKeys.some((k) => key.includes(k));
+function containsIgnoredKeywordsInValue(value: string) {
+  const ignoredKeywords = ["git", "path"];
+  return ignoredKeywords.some((v) => value.includes(v));
+}
+
+function containsIgnoredKeywordsInKey(key: string) {
+  const ignoredKeywords = ["."];
+  return ignoredKeywords.some((k) => key.includes(k));
 }


### PR DESCRIPTION
**Description**:  
This PR resolves [Issue #208](https://github.com/filllabs/dependi/issues/208) by fixing the TOML parser to reject invalid package names like `rf.features`.  

### Changes:  
- Added `containsIgnoredKeywordsInKey` to filter out keys containing invalid characters (e.g., `"."`).  
- Updated parsing logic to ensure such keys are excluded.  

### Impact:  
Improves the accuracy of dependency parsing by preventing invalid package names from being processed.