### PR TITLE
Add support for parsing pubspec.yaml files (Dart / Flutter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Dependi: Your Ultimate Dependency Management Tool
 
-Dependi is a comprehensive dependency management extension that helps developers write code faster and smarter by efficiently managing project dependencies. Formerly known as Crates the most loved and used dependency management extension for Rust. Dependi now supports multiple languages including Rust, Go, JavaScript, TypeScript, Python and PHP.
+Dependi is a comprehensive dependency management extension that helps developers write code faster and smarter by efficiently managing project dependencies. Formerly known as Crates the most loved and used dependency management extension for Rust. Dependi now supports multiple languages including Rust, Go, JavaScript, TypeScript, Python, PHP and Dart.
 
 [Install](https://www.dependi.io/download) Dependi via VSCode or [Dependi.io](https://www.dependi.io)
 
 
 When you install Dependi in Visual Studio Code, 2 options are available :
 
-- Dependi Core: Provides essential dependency management for Rust, Go, JavaScript, TypeScript, Python and PHP projects. Free to use with no subscription required.
+- Dependi Core: Provides essential dependency management for Rust, Go, JavaScript, TypeScript, Python, PHP and Dart projects. Free to use with no subscription required.
 
 - [Dependi Pro:](https://www.dependi.io) Offers many advanced features like detailed vulnerability reports, private repository support, and priority support... Easy subscription packages and [free trials](https://www.dependi.io/#pricing) are available.
 
@@ -35,6 +35,9 @@ Dependi simplifies dependency management in Visual Studio Code, helping you to:
   - **PHP**:
     - Documentation: [https://www.php.net/docs.php](https://www.php.net/docs.php)
     - Package Repository (Packagist): [https://repo.packagist.org](https://repo.packagist.org)
+  - **Dart / Flutter**:
+    - Documentation: [https://dart.dev/docs](https://dart.dev/docs)
+    - Package Repository (pub.dev): [https://pub.dev](https://pub.dev)
     
 - **Vulnerabilities at a Glance**: Quickly identify vulnerabilities in your project dependencies and take action to mitigate risks.
   ![Vulnerabilities at a Glance](https://www.dependi.io/screenshots/vuln.png)
@@ -42,7 +45,7 @@ Dependi simplifies dependency management in Visual Studio Code, helping you to:
 - **Vulnerability Reports**: Generate comprehensive reports detailing the vulnerabilities in your dependencies, helping you maintain secure codebases.
   ![Vulnerability Reports](https://www.dependi.io/screenshots/report.png)
 
-- **Supported Languages and Frameworks**: Dependi works with a variety of languages including Rust, Go, JavaScript, TypeScript,  Python and PHP. It is designed to support most popular languages and frameworks, making it a versatile tool for developers.
+- **Supported Languages and Frameworks**: Dependi works with a variety of languages including Rust, Go, JavaScript, TypeScript,  Python, PHP and Dart. It is designed to support most popular languages and frameworks, making it a versatile tool for developers.
 
 For more information about the feature set [visit here](https://www.dependi.io/#features).
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,12 +1,12 @@
 # Dependi: Your Ultimate Dependency Management Tool
 
-Dependi is a comprehensive dependency management extension that helps developers write code faster and smarter by efficiently managing project dependencies. Formerly known as Crates the most loved and used dependency management extension for Rust. Dependi now supports multiple languages including Rust, Go, JavaScript, TypeScript, Python and PHP.
+Dependi is a comprehensive dependency management extension that helps developers write code faster and smarter by efficiently managing project dependencies. Formerly known as Crates the most loved and used dependency management extension for Rust. Dependi now supports multiple languages including Rust, Go, JavaScript, TypeScript, Python, PHP and Dart.
 
 [Install](https://www.dependi.io/download) Dependi via VSCode or [Dependi.io](https://www.dependi.io)
 
 When you install Dependi in Visual Studio Code, 2 options are available :
 
-- Dependi Core: Provides essential dependency management for Rust, Go, JavaScript, TypeScript, Python and PHP projects. Free to use with no subscription required.
+- Dependi Core: Provides essential dependency management for Rust, Go, JavaScript, TypeScript, Python, PHP and Dart projects. Free to use with no subscription required.
 
 - [Dependi Pro:](https://www.dependi.io) Offers many advanced features like detailed vulnerability reports, private repository support, and priority support... Easy subscription packages and [free trials](https://www.dependi.io/#pricing) are available.
 
@@ -38,6 +38,9 @@ Dependi simplifies dependency management in Visual Studio Code, helping you to:
   - **PHP**:
     - Documentation: [https://www.php.net/docs.php](https://www.php.net/docs.php)
     - Package Repository (Packagist): [https://repo.packagist.org](https://repo.packagist.org)
+  - **Dart / Flutter**:
+    - Documentation: [https://dart.dev/docs](https://dart.dev/guides)
+    - Package Repository (pub.dev): [https://pub.dev](https://pub.dev)
 
 - **Vulnerabilities at a Glance**: Quickly identify vulnerabilities in your project dependencies and take action to mitigate risks.
   ![Vulnerabilities at a Glance](https://www.dependi.io/screenshots/vuln.png)
@@ -45,7 +48,7 @@ Dependi simplifies dependency management in Visual Studio Code, helping you to:
 - **Vulnerability Reports**: Generate comprehensive reports detailing the vulnerabilities in your dependencies, helping you maintain secure codebases.
   ![Vulnerability Reports](https://www.dependi.io/screenshots/report.png)
 
-- **Supported Languages and Frameworks**: Dependi works with a variety of languages including Rust, Go, JavaScript, TypeScript, Python and PHP. It is designed to support most popular languages and frameworks, making it a versatile tool for developers.
+- **Supported Languages and Frameworks**: Dependi works with a variety of languages including Rust, Go, JavaScript, TypeScript, Python, PHP and Dart. It is designed to support most popular languages and frameworks, making it a versatile tool for developers.
 
 For more information about the feature set [visit here](https://www.dependi.io/#features).
 
@@ -102,6 +105,12 @@ While Dependi works out-of-the-box without any configuration, we also offer a fe
 - `dependi.php.unstableFilter`: Filter unstable versions: Exclude, Include Always, or Include If Unstable.
 - `dependi.php.ignoreLinePattern`: Matches lines based on `*` position: `text*`, `*text`, `*text*`. Multiple patterns can be used, separated by commas.
 - `dependi.php.silenceVersionOverflows`: Consider non-registry versions of packages as up-to-date if their version exceeds the registry version.
+- `dependi.dart.enabled`: Enable Dart package management.
+- `dependi.dart.lockFileEnabled`: Enable checking for Dart dependencies in lockfiles.
+- `dependi.dart.indexServerURL`: The URL for the Dart package index server.
+- `dependi.dart.unstableFilter`: Filter unstable versions: Exclude, Include Always, or Include If Unstable.
+- `dependi.dart.ignoreLinePattern`: Matches lines based on `*` position: `text*`, `*text`, `*text*`. Multiple patterns can be used, separated by commas.
+- `dependi.dart.silenceVersionOverflows`: Consider non-registry versions of packages as up-to-date if their version exceeds the registry version.
 - `dependi.vulnerability.enabled`: Enable checking for vulnerabilities in dependencies.
 - `dependi.vulnerability.ghsa.enabled`: Include GitHub Security Advisory vulnerabilities in checks.
 - `dependi.vulnerability.osvQueryURL.batch`: The URL for batch querying vulnerabilities via OSV.

--- a/vscode/changelog.md
+++ b/vscode/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "dependi" extension will be documented in this file.
 
+## [v0.7.15](https://github.com/filllabs/dependi/compare/v0.7.14...v0.7.15)
+
+### New Features
+
+- Add support for `pubspec.yaml` files — Dart & Flutter dependencies are now parsed and displayed. ([Issue #231](https://github.com/filllabs/dependi/issues/231))
+
 ## [v0.7.14](https://github.com/filllabs/dependi/compare/v0.7.13...v0.7.14)
 
 ### Improvements

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependi",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dependi",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@neuralegion/cvss": "1.2.2",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -525,6 +525,72 @@
         }
       },
       {
+        "title": "Dart Settings",
+        "properties": {
+          "dependi.dart.enabled": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": true,
+            "description": "Enable checking for Dart dependencies.",
+            "order": 38
+          },
+          "dependi.dart.indexServerURL": {
+            "type": "string",
+            "scope": "resource",
+            "description": "The URL for the Dart package index server.",
+            "format": "url",
+            "pattern": "^https?://(?!.*//)([^/]+/)*[^/]+$",
+            "default": "https://pub.dev",
+            "order": 39
+          },
+          "dependi.dart.unstableFilter": {
+            "type": "string",
+            "enum": [
+              "Exclude",
+              "IncludeAlways",
+              "IncludeIfUnstable"
+            ],
+            "default": "Exclude",
+            "scope": "resource",
+            "enumDescriptions": [
+              "Exclude them (default)",
+              "Include them and always consider as latest",
+              "Include if the current version is already unstable"
+            ],
+            "description": "Filter unstable versions: Exclude, Include Always, or Include If Unstable.",
+            "order": 40
+          },
+          "dependi.dart.ignoreLinePatterns": {
+            "type": "string",
+            "scope": "resource",
+            "default": "",
+            "markdownDescription": "Matches lines based on `*` position: `text*`, `*text`, `*text*`. Multiple patterns can be used, separated by commas.",
+            "order": 41
+          },
+          "dependi.dart.informPatchUpdates": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": false,
+            "description": "Inform about available patch updates for Dart packages via decoration.",
+            "order": 42
+          },
+          "dependi.dart.lockFileEnabled": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": true,
+            "description": "Enable checking for Dart dependencies in lockfiles.",
+            "order": 43
+          },
+          "dependi.dart.silenceVersionOverflows": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": false,
+            "description": "Consider non-registry packages as up-to-date if their version exceeds the max.",
+            "order": 44
+          }
+        }
+      },
+      {
         "title": "Vulnerability Settings",
         "properties": {
           "dependi.vulnerability.enabled": {
@@ -532,14 +598,14 @@
             "scope": "resource",
             "default": true,
             "description": "Enable checking for vulnerabilities in dependencies.",
-            "order": 38
+            "order": 45
           },
           "dependi.vulnerability.ghsa.enabled": {
             "type": "boolean",
             "scope": "resource",
             "default": false,
             "description": "Include GitHub Security Advisory vulnerabilities in checks.",
-            "order": 39
+            "order": 46
           },
           "dependi.vulnerability.osvQueryURL.batch": {
             "type": "string",
@@ -548,7 +614,7 @@
             "format": "url",
             "pattern": "^https?://(?!.*//)([^/]+/)*[^/]+$",
             "default": "https://api.osv.dev/v1/querybatch",
-            "order": 40
+            "order": 47
           },
           "dependi.vulnerability.osvQueryURL.single": {
             "type": "string",
@@ -557,7 +623,7 @@
             "format": "url",
             "pattern": "^https?://(?!.*//)([^/]+/)*[^/]+$",
             "default": "https://api.osv.dev/v1/query",
-            "order": 41
+            "order": 48
           }
         }
       },
@@ -867,7 +933,7 @@
             "order": 20
           }
         }
-      },  
+      },
       {
         "title": "Extras",
         "properties": {

--- a/vscode/src/api/indexes/dependi/reports.ts
+++ b/vscode/src/api/indexes/dependi/reports.ts
@@ -38,6 +38,7 @@ export enum Language {
   JS,
   Python,
   PHP,
+  Dart,
 }
 
 const LanguageArray = [

--- a/vscode/src/api/indexes/pubdev.ts
+++ b/vscode/src/api/indexes/pubdev.ts
@@ -1,0 +1,48 @@
+import { Settings } from "../../config";
+import { DependencyInfo } from "../DepencencyInfo";
+import { getReqOptions } from "../utils";
+import {
+  addResponseHandlers,
+  cleanURL,
+  isStatusInvalid,
+  ResponseError,
+} from "./utils";
+import { ClientRequest, IncomingMessage } from "http";
+import { makeRequest } from "./request";
+
+export const versions = (name: string) => {
+  return new Promise<DependencyInfo>(function (resolve, reject) {
+    const url = getURL(name);
+    const options = getReqOptions(url);
+
+    const handleResponse = (res: IncomingMessage, req: ClientRequest) => {
+      if (isStatusInvalid(res)) {
+        return reject(ResponseError(res));
+      }
+      const body = addResponseHandlers(name, res, req, reject);
+      let info: DependencyInfo;
+      res.on("end", () => {
+        try {
+          const response = JSON.parse(Buffer.concat(body).toString());
+          const versions = response.versions;
+          const filteredVersions = Object.keys(versions).map((i: any) => {
+            return versions[i].version;
+          });
+          info = {
+            name: name,
+            versions: filteredVersions,
+          };
+        } catch (e) {
+          reject(e);
+        }
+        resolve(info);
+      });
+    };
+
+    makeRequest(options, handleResponse, reject);
+  });
+};
+
+function getURL(name: string) {
+  return cleanURL(`${Settings.dart.index}/api/packages/${name}`);
+}

--- a/vscode/src/commands/lock-file/disableLockFileParsing.ts
+++ b/vscode/src/commands/lock-file/disableLockFileParsing.ts
@@ -21,6 +21,9 @@ export const disableLockFileParsing = commands.registerTextEditorCommand(
         case Language.Python:
           config.update(Configs.PYTHON_ENABLED_LOCK_FILE, false);
           break;
+        case Language.Dart:
+          config.update(Configs.DART_ENABLED_LOCK_FILE, false);
+          break;
         default:
           break;
       }

--- a/vscode/src/commands/lock-file/enableLockFileParsing.ts
+++ b/vscode/src/commands/lock-file/enableLockFileParsing.ts
@@ -22,6 +22,9 @@ export const enableLockFileParsing = commands.registerTextEditorCommand(
         case Language.Python:
           config.update(Configs.PYTHON_ENABLED_LOCK_FILE, true);
           break;
+        case Language.Dart:
+          config.update(Configs.DART_ENABLED_LOCK_FILE, true);
+          break;
         default:
           break;
       }

--- a/vscode/src/commands/lock-file/lockFileParsed.ts
+++ b/vscode/src/commands/lock-file/lockFileParsed.ts
@@ -22,6 +22,9 @@ export const lockFileParsed = commands.registerTextEditorCommand(
         case Language.Python:
           config.update(Configs.PYTHON_ENABLED_LOCK_FILE, false);
           break;
+        case Language.Dart:
+          config.update(Configs.DART_ENABLED_LOCK_FILE, false);
+          break;
         default:
           break;
       }

--- a/vscode/src/config.ts
+++ b/vscode/src/config.ts
@@ -50,6 +50,14 @@ export enum Configs {
   PYTHON_ENABLED_LOCK_FILE = `python.lockFileEnabled`,
   PYTHON_SILENCE_VERSION_OVERFLOWS = `python.silenceVersionOverflows`,
 
+  DART_ENABLED = `dart.enabled`,
+  DART_INDEX_SERVER_URL = `dart.indexServerURL`,
+  DART_UNSTABLE_FILTER = `dart.unstableFilter`,
+  DART_IGNORE_LINE_PATTERN = `dart.ignoreLinePattern`,
+  DART_INFORM_PATCH_UPDATES = `dart.informPatchUpdates`,
+  DART_ENABLED_LOCK_FILE = `dart.lockFileEnabled`,
+  DART_SILENCE_VERSION_OVERFLOWS = `dart.silenceVersionOverflows`,
+
   VULS_ENABLED = `vulnerability.enabled`,
   VULS_GHSA_ENABLED = `vulnerability.ghsa.enabled`,
   VULS_OSV_BATCH_URL = `vulnerability.osvQueryURL.batch`,
@@ -144,6 +152,15 @@ export const Settings = {
     lockFileEnabled: true,
     silenceVersionOverflows: false
   },
+  dart: {
+    enabled: true,
+    index: "",
+    unstableFilter: UnstableFilter.Exclude,
+    ignoreLinePattern: "",
+    informPatchUpdates: false,
+    lockFileEnabled: true,
+    silenceVersionOverflows: false
+  },
   vulnerability: {
     enabled: false,
     ghsa: false,
@@ -225,6 +242,14 @@ export const Settings = {
     this.python.informPatchUpdates = config.get<boolean>(Configs.PYTHON_INFORM_PATCH_UPDATES) ?? false;
     this.python.lockFileEnabled = config.get<boolean>(Configs.PYTHON_ENABLED_LOCK_FILE) ?? true;
     this.python.silenceVersionOverflows = config.get<boolean>(Configs.PYTHON_SILENCE_VERSION_OVERFLOWS) ?? false;
+
+    this.dart.enabled = config.get<boolean>(Configs.DART_ENABLED) ?? true;
+    this.dart.index = config.get<string>(Configs.DART_INDEX_SERVER_URL) || "https://pub.dev";
+    this.dart.unstableFilter = UnstableFilter[config.get<string>(Configs.DART_UNSTABLE_FILTER) as keyof typeof UnstableFilter] || UnstableFilter.Exclude;
+    this.dart.ignoreLinePattern = config.get<string>(Configs.DART_IGNORE_LINE_PATTERN) || "";
+    this.dart.informPatchUpdates = config.get<boolean>(Configs.DART_INFORM_PATCH_UPDATES) ?? false;
+    this.dart.lockFileEnabled = config.get<boolean>(Configs.DART_ENABLED_LOCK_FILE) ?? true;
+    this.dart.silenceVersionOverflows = config.get<boolean>(Configs.DART_SILENCE_VERSION_OVERFLOWS) ?? false;
 
     this.vulnerability.enabled = config.get<boolean>(Configs.VULS_ENABLED) ?? true;
     this.vulnerability.ghsa = config.get<boolean>(Configs.VULS_GHSA_ENABLED) ?? false;

--- a/vscode/src/core/Language.ts
+++ b/vscode/src/core/Language.ts
@@ -10,6 +10,7 @@ export enum Language {
     JS = 3,
     Python = 4,
     PHP = 5,
+    Dart = 6,
 }
 
 export enum OCVEnvironment {
@@ -18,6 +19,7 @@ export enum OCVEnvironment {
     Packagist = "Packagist",
     Pypi = "PyPI",
     Go = "Go",
+    Dart = "Pub",
 }
 export var CurrentLanguage: Language = Language.None;
 export var CurrentLanguageConfig: string = "";
@@ -43,6 +45,8 @@ export function setLanguage(file?: string) {
             return setLanguageConfig(Language.Python, "python", filename, OCVEnvironment.Pypi, Settings.python.lockFileEnabled);
         case "pixi.toml":
             return setLanguageConfig(Language.Python, "python", filename, OCVEnvironment.Pypi, Settings.python.lockFileEnabled);
+        case "pubspec.yaml":
+            return setLanguageConfig(Language.Dart, "dart", filename, OCVEnvironment.Dart);    
         default:
             if ((fileExtension === ".txt" || fileExtension === ".in") &&  filename.toLowerCase().startsWith("requirement")) {
                 return setLanguageConfig(Language.Python, "python", filename, OCVEnvironment.Pypi, Settings.python.lockFileEnabled);

--- a/vscode/src/core/fetchers/PubDevFetcher.ts
+++ b/vscode/src/core/fetchers/PubDevFetcher.ts
@@ -1,0 +1,23 @@
+
+import { versions } from "../../api/indexes/pubdev";
+import { Settings } from "../../config";
+import compareVersions from "../../semver/compareVersions";
+import { fetcherCatch } from "../../utils/errors";
+import Dependency from "../Dependency";
+import { Fetcher } from "./fetcher";
+
+export class PubDevFetcher extends Fetcher {
+
+  fetch(): (i: Dependency) => Promise<Dependency> {
+    const base = this;
+    return async function (dep: Dependency): Promise<Dependency> {
+      return versions(dep.item.key).then((mod) => {
+        const versions = mod.versions
+          .filter((i: string) => i !== "" && i !== undefined && !base.checkUnstables(Settings.dart.unstableFilter, i, dep.item.value!))
+          .sort(compareVersions).reverse();
+        dep.versions = versions;
+        return dep;
+      }).catch(fetcherCatch(dep));
+    };
+  };
+}

--- a/vscode/src/core/fetchers/fetcher.ts
+++ b/vscode/src/core/fetchers/fetcher.ts
@@ -116,6 +116,9 @@ function checkPreRelease(version: string): boolean {
     version.indexOf("-canary") !== -1 ||
     version.indexOf("-pre") !== -1 ||
     version.indexOf("-next") !== -1 ||
-    version.indexOf("-nightly") !== -1
+    version.indexOf("-nightly") !== -1 ||
+    version.indexOf("-nullsafety") !== -1 ||
+    version.indexOf("-nnbd") !== -1 ||
+    version.indexOf("+") !== -1
   );
 }

--- a/vscode/src/core/listeners/PubspecListener.ts
+++ b/vscode/src/core/listeners/PubspecListener.ts
@@ -1,0 +1,13 @@
+import { Fetcher } from "../fetchers/fetcher";
+import { Language } from "../Language";
+import { Parser } from "../parsers/parser";
+import { JsonListener } from "./JsonListener";
+
+export class PubspecListener extends JsonListener {
+	constructor(
+		public fetcher: Fetcher,
+		public parser: Parser,
+	) {
+		super(fetcher, parser, Language.Dart);
+	}
+}

--- a/vscode/src/core/listeners/index.ts
+++ b/vscode/src/core/listeners/index.ts
@@ -23,6 +23,9 @@ import { NpmListener } from "./NpmListener";
 import { PhpListener } from './PhpListener';
 import { PypiListener } from "./PypiListener";
 import { Listener } from "./listener";
+import { PubspecListener } from "./PubspecListener";
+import { PubDevFetcher } from "../fetchers/PubDevFetcher";
+import { PubspecParser } from "../parsers/PubspecParser";
 
 
 export default async function listener(editor: TextEditor | undefined): Promise<void> {
@@ -72,6 +75,14 @@ export default async function listener(editor: TextEditor | undefined): Promise<
       listener = new PypiListener(
         new PypiFetcher(Settings.python.index, Configs.PYTHON_INDEX_SERVER_URL),
         parser);
+      break;
+    case Language.Dart:
+      if (!Settings.dart.enabled)
+        return;
+      listener = new PubspecListener(
+        new PubDevFetcher(Settings.dart.index, Configs.DART_INDEX_SERVER_URL),
+        new PubspecParser());
+      break;
   }
   if (listener !== undefined) {
     if (Settings.api.key !== "" && Settings.api.url !== "") {

--- a/vscode/src/core/parsers/PubspecLockParser.ts
+++ b/vscode/src/core/parsers/PubspecLockParser.ts
@@ -1,0 +1,50 @@
+import { satisfies } from "semver";
+import Item from "../Item";
+import { clearText, isPackagePresent, setLockValue } from "./TomlLockParser";
+
+export class State {
+  lockedValue: string;
+  dependency: string;
+  constructor() {
+    this.lockedValue = "";
+    this.dependency = "";
+  }
+}
+
+export class PubspecLockParser {
+  constructor() {}
+
+  parse(fileContent: string, items: Item[]): Item[] {
+    const doc = fileContent.split("\n");
+    const state = new State();
+    for (let row = 0; row < doc.length; row++) {
+      let line = doc[row];
+      if (line.trim().startsWith("name:")) {
+        state.dependency = this.getPackageName(line);
+        if (isPackagePresent(items, state.dependency)) {
+          for (row++; row < doc.length; row++) {
+            line = doc[row];
+            if (line.trim().startsWith("version:")) {
+              state.lockedValue = this.getParsedVersion(line);
+              setLockValue(state, items);
+              row++;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    return items;
+  }
+
+  getPackageName(line: string): string {
+    let packageName = line.split("name:")[1];
+    return clearText(packageName);
+  }
+
+  getParsedVersion(line: string): string {
+    let packageVersion = line.split("version:")[1];
+    return clearText(packageVersion);
+  }
+}

--- a/vscode/src/core/parsers/PubspecParser.ts
+++ b/vscode/src/core/parsers/PubspecParser.ts
@@ -1,0 +1,122 @@
+import { TextDocument, TextLine, window, commands } from "vscode";
+import Item from "../Item";
+import { isQuote, shouldIgnoreLine } from "./utils";
+import { Settings } from "../../config";
+import path from "path";
+import fs from "fs";
+import { PubspecLockParser } from "./PubspecLockParser";
+
+export class PubspecParser {
+  parse(doc: TextDocument): Item[] {
+    let items: Item[] = [];
+    let isInDependencySection = false; // Simple boolean state
+
+    for (let row = 0; row < doc.lineCount; row++) {
+      const line = doc.lineAt(row);
+
+      if (shouldIgnoreLine(line, Settings.dart.ignoreLinePattern, ["#"])) {
+        continue;
+      }
+
+      const firstCharIndex = line.firstNonWhitespaceCharacterIndex;
+
+      if (firstCharIndex === 0) {
+        isInDependencySection = isDependencySection(line);
+      } else if (isInDependencySection && firstCharIndex === 2) {
+        // Lines indented by 2 spaces within a dependency section are likely dependencies
+        const item = parsePair(line);
+        if (item) {
+          items.push(item);
+        }
+      }
+    }
+    return Settings.dart.lockFileEnabled ? parseLockFile(items) : items;
+  }
+}
+
+function isDependencySection(line: TextLine): boolean {
+  const dependencySectionKeys = ["dependencies:", "dev_dependencies:"];
+  const trimmedLineText = line.text.trim();
+  return dependencySectionKeys.some((key) => trimmedLineText === key);
+}
+
+function parsePair(line: TextLine): Item | undefined {
+  const item = new Item();
+  const lineText = line.text;
+
+  const colonIndex = lineText.indexOf(":");
+  if (colonIndex === -1) {
+    return undefined;
+  }
+
+  item.key = lineText.substring(0, colonIndex).trim();
+
+  const valueString = lineText.substring(colonIndex + 1).trim();
+  const commentIndex = valueString.indexOf("#");
+  let cleanValueString =
+    commentIndex !== -1
+      ? valueString.substring(0, commentIndex).trim()
+      : valueString;
+
+  item.value = cleanValueString;
+  item.start = line.text.indexOf(cleanValueString, colonIndex + 1);
+  item.end = item.start + cleanValueString.length;
+  if (isQuote(cleanValueString[0]) && isQuote(cleanValueString[cleanValueString.length - 1])) {
+    item.value = cleanValueString.substring(1, cleanValueString.length - 1);
+    item.start += 1;
+    item.end -= 1;
+  }
+
+  if (!isValidValue(item.value)) {
+    return undefined;
+  }
+
+  item.line = line.lineNumber;
+  item.endOfLine = line.range.end.character;
+  item.createRange();
+  item.createDecoRange();
+
+  return item;
+}
+
+function isValidValue(value: string): boolean {
+  if (!value || value === undefined) {
+    return false;
+  }
+
+  if (value === "any") {
+    return true;
+  }
+
+  const constraints = value.split(/\s+/).filter((c) => c.length > 0);
+
+  if (constraints.length === 0) {
+    return false;
+  }
+  const singleConstraintPattern = /^[<>~=^]?=?\s*\d+(\.\d+)*([\-+]?\w+)*$/;
+
+  return constraints.every((constraint) =>
+    singleConstraintPattern.test(constraint)
+  );
+}
+
+function parseLockFile(item: Item[]): Item[] {
+  const filePath = window.activeTextEditor?.document.uri.fsPath;
+  const dirName = path.dirname(filePath || "");
+  try {
+    const files = fs.readdirSync(dirName);
+    const lockFile = files.find((file) => file.endsWith(".lock"));
+    if (lockFile) {
+      const lockFilePath = path.join(dirName, lockFile);
+      const fileContent = fs.readFileSync(lockFilePath, "utf8");
+      const LockFileParser = new PubspecLockParser();
+      item = LockFileParser.parse(fileContent, item);
+      commands.executeCommand("setContext", "dependi.hasLockFile", true);
+    } else {
+      commands.executeCommand("setContext", "dependi.hasLockFile", false);
+    }
+  } catch (err) {
+    console.error(err);
+  }
+  return item;
+}

--- a/vscode/src/core/parsers/TomlLockParser.ts
+++ b/vscode/src/core/parsers/TomlLockParser.ts
@@ -2,11 +2,9 @@ import { satisfies } from "semver";
 import Item from "../Item";
 
 export class State {
-  isTable: boolean;
   lockedValue: string;
   dependency: string;
   constructor() {
-    this.isTable = false;
     this.lockedValue = "";
     this.dependency = "";
   }
@@ -28,7 +26,7 @@ export class TomlLockFileParser {
             line = doc[++row];
             if (line.startsWith("version")) {
               state.lockedValue = this.getParsedVersion(line);
-              this.setLockValue(state, items);
+              setLockValue(state, items);
               row++;
             }
           }
@@ -41,19 +39,6 @@ export class TomlLockFileParser {
 
   isTableSection(line: string): boolean {
     return line.startsWith("[[") && line.endsWith("]]");
-  }
-
-  setLockValue(state: State, items: Item[]): void {
-    let foundItem = items.find((item) => item.key === state.dependency);
-    if (
-      foundItem &&
-      (!foundItem.lockedAt ||
-        (foundItem.value && satisfies(state.lockedValue, foundItem.value)))
-    ) {
-      foundItem.lockedAt = state.lockedValue;
-    }
-    state.lockedValue = "";
-    state.dependency = "";
   }
 
   getPackageName(line: string): string {
@@ -72,4 +57,17 @@ export function isPackagePresent(items: Item[], packageName: string): boolean {
 }
 export function clearText(text: string) {
   return text.replace(/[^a-zA-Z0-9-_.*+]/g, "").trim();
+}
+
+export function setLockValue(state: State, items: Item[]): void {
+  let foundItem = items.find((item) => item.key === state.dependency);
+  if (
+    foundItem &&
+    (!foundItem.lockedAt ||
+      (foundItem.value && satisfies(state.lockedValue, foundItem.value)))
+  ) {
+    foundItem.lockedAt = state.lockedValue;
+  }
+  state.lockedValue = "";
+  state.dependency = "";
 }

--- a/vscode/src/semver/semverUtils.ts
+++ b/vscode/src/semver/semverUtils.ts
@@ -142,6 +142,8 @@ function treatAsUpToDate(): boolean {
       return Settings.go.silenceVersionOverflows;
     case Language.Python:
       return Settings.python.silenceVersionOverflows;
+    case Language.Dart:
+      return Settings.dart.silenceVersionOverflows;
   }
   return false;
 }

--- a/vscode/src/ui/decoration.ts
+++ b/vscode/src/ui/decoration.ts
@@ -162,6 +162,8 @@ function getLinks(lang: Language, key: string): string {
       return ` _([View package](https://packagist.org/packages/${cleanKey}))_`;
     case Language.Python:
       return ` _([View package](https://pypi.org/project/${cleanKey}))_`;
+    case Language.Dart:
+      return ` _([View package](https://pub.dev/packages/${cleanKey}))_`;
     default:
       return '';
   }
@@ -179,6 +181,8 @@ function getDocsLink(lang: Language, key: string, version: string): string {
       return `[(docs)](https://packagist.org/packages/${key}#${version})`;
     case Language.Python:
       return `[(docs)](https://pypi.org/project/${key}/${version})`;
+    case Language.Dart:
+      return `[(docs)](https://pub.dev/packages/${key}/versions/${version})`;
     default:
       return '';
   }


### PR DESCRIPTION
### Summary
This PR introduces initial support for parsing pubspec.yaml files used in Dart and Flutter projects.

### Changes
- Added parser for pubspec.yaml files
- Integrated with existing dependency resolution flow
- Updated changelog.md and README.MD

### Related Issue
#231 