### PR TITLE
feat(helm): add support for Helm Chart.yaml dependencies

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "none",
+  "printWidth": 160
+}

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,12 +1,12 @@
 # Dependi: Your Ultimate Dependency Management Tool
 
-Dependi is a comprehensive dependency management extension that helps developers write code faster and smarter by efficiently managing project dependencies. Formerly known as Crates the most loved and used dependency management extension for Rust. Dependi now supports multiple languages including Rust, Go, JavaScript, TypeScript, Python, PHP and Dart.
+Dependi is a comprehensive dependency management extension that helps developers write code faster and smarter by efficiently managing project dependencies. Formerly known as Crates the most loved and used dependency management extension for Rust. Dependi now supports multiple languages including Rust, Go, JavaScript, TypeScript, Python, PHP, Dart and Helm.
 
 [Install](https://www.dependi.io/download) Dependi via VSCode or [Dependi.io](https://www.dependi.io)
 
 When you install Dependi in Visual Studio Code, 2 options are available :
 
-- Dependi Core: Provides essential dependency management for Rust, Go, JavaScript, TypeScript, Python, PHP and Dart projects. Free to use with no subscription required.
+- Dependi Core: Provides essential dependency management for Rust, Go, JavaScript, TypeScript, Python, PHP, Dart and Helm Chart projects. Free to use with no subscription required.
 
 - [Dependi Pro:](https://www.dependi.io) Offers many advanced features like detailed vulnerability reports, private repository support, and priority support... Easy subscription packages and [free trials](https://www.dependi.io/#pricing) are available.
 
@@ -48,7 +48,7 @@ Dependi simplifies dependency management in Visual Studio Code, helping you to:
 - **Vulnerability Reports**: Generate comprehensive reports detailing the vulnerabilities in your dependencies, helping you maintain secure codebases.
   ![Vulnerability Reports](https://www.dependi.io/screenshots/report.png)
 
-- **Supported Languages and Frameworks**: Dependi works with a variety of languages including Rust, Go, JavaScript, TypeScript, Python, PHP and Dart. It is designed to support most popular languages and frameworks, making it a versatile tool for developers.
+- **Supported Languages and Frameworks**: Dependi works with a variety of languages including Rust, Go, JavaScript, TypeScript, Python, PHP, Dart and Helm. It is designed to support most popular languages and frameworks, making it a versatile tool for developers.
 
 For more information about the feature set [visit here](https://www.dependi.io/#features).
 
@@ -111,6 +111,11 @@ While Dependi works out-of-the-box without any configuration, we also offer a fe
 - `dependi.dart.unstableFilter`: Filter unstable versions: Exclude, Include Always, or Include If Unstable.
 - `dependi.dart.ignoreLinePattern`: Matches lines based on `*` position: `text*`, `*text`, `*text*`. Multiple patterns can be used, separated by commas.
 - `dependi.dart.silenceVersionOverflows`: Consider non-registry versions of packages as up-to-date if their version exceeds the registry version.
+- `dependi.helm.enabled`: Enable Helm Chart dependency management.
+- `dependi.helm.unstableFilter`: Filter unstable chart versions: Exclude, Include Always, or Include If Unstable.
+- `dependi.helm.ignoreLinePattern`: Regex pattern to ignore lines in Chart.yaml dependencies parsing.
+- `dependi.helm.informPatchUpdates`: Inform about available patch updates for Helm charts.
+- `dependi.helm.silenceVersionOverflows`: Consider chart as up-to-date if its version exceeds repository max.
 - `dependi.vulnerability.enabled`: Enable checking for vulnerabilities in dependencies.
 - `dependi.vulnerability.ghsa.enabled`: Include GitHub Security Advisory vulnerabilities in checks.
 - `dependi.vulnerability.osvQueryURL.batch`: The URL for batch querying vulnerabilities via OSV.
@@ -131,7 +136,7 @@ While Dependi works out-of-the-box without any configuration, we also offer a fe
 
 - `dependi.extras.silenceUpdateMessages`: This setting hides informational update messages when enabled (true).
 
-### Cargo.toml, go.mod, package.json and requirements.txt
+### Cargo.toml, go.mod, package.json, requirements.txt and Chart.yaml
 
 - `# dependi: disable-check`: Disable version check for this specific dependency.
 

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "dependi",
-  "version": "0.7.15",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dependi",
-      "version": "0.7.15",
+      "version": "0.8.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@neuralegion/cvss": "1.2.2",
         "fast-toml": "0.5.4",
         "node-cache": "5.1.2",
         "release-please": "16.12.0",
-        "semver": "7.6.3"
+        "semver": "7.6.3",
+        "yaml": "2.5.0"
       },
       "devDependencies": {
         "@types/glob": "8.1.0",
@@ -29,6 +30,7 @@
         "eslint": "9.9.0",
         "glob": "11.0.0",
         "mocha": "10.7.3",
+        "ts-node": "10.9.2",
         "typescript": "5.5.4"
       },
       "engines": {
@@ -140,6 +142,19 @@
       "dependencies": {
         "unist-util-visit": "^2.0.3",
         "unist-util-visit-parents": "^3.1.1"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -748,6 +763,34 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@neuralegion/cvss": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@neuralegion/cvss/-/cvss-1.2.2.tgz",
@@ -976,6 +1019,34 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/glob": {
       "version": "8.1.0",
@@ -1286,6 +1357,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
@@ -1356,6 +1440,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1815,6 +1906,13 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3180,6 +3278,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/map-obj": {
       "version": "4.3.0",
@@ -4568,6 +4673,60 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
@@ -4687,6 +4846,13 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -4866,9 +5032,10 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
-      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
+      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -4965,6 +5132,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "dependi",
   "displayName": "Dependi",
-  "description": "Empowers developers to efficiently manage dependencies and address vulnerabilities in Rust, Go, JavaScript, Typescript, PHP and Python projects.",
-  "version": "0.7.15",
+  "description": "Empowers developers to efficiently manage dependencies and address vulnerabilities in Rust, Go, JavaScript, Typescript, PHP, Python and Helm Chart projects.",
+  "version": "0.8.0",
   "publisher": "fill-labs",
   "author": {
     "name": "Fill Labs",
@@ -49,7 +49,10 @@
     "vulnerability",
     "security",
     "update",
-    "toml"
+    "toml",
+    "helm",
+    "chart",
+    "kubernetes"
   ],
   "categories": [
     "Programming Languages",
@@ -73,7 +76,9 @@
     "onLanguage:pixi.toml",
     "workspaceContains:**/pixi.toml",
     "onLanguage:pyproject.toml",
-    "workspaceContains:**/pyproject.toml"
+    "workspaceContains:**/pyproject.toml",
+    "onLanguage:Chart.yaml",
+    "workspaceContains:**/Chart.yaml"
   ],
   "contributes": {
     "menus": {
@@ -591,6 +596,56 @@
         }
       },
       {
+        "title": "Helm Settings",
+        "properties": {
+          "dependi.helm.enabled": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": true,
+            "description": "Enable checking for Helm Chart dependencies.",
+            "order": 145
+          },
+          "dependi.helm.unstableFilter": {
+            "type": "string",
+            "enum": [
+              "Exclude",
+              "IncludeAlways",
+              "IncludeIfUnstable"
+            ],
+            "default": "Exclude",
+            "scope": "resource",
+            "enumDescriptions": [
+              "Exclude them (default)",
+              "Include them and always consider as latest",
+              "Include if the current version is already unstable"
+            ],
+            "description": "Filter unstable chart versions: Exclude, Include Always, or Include If Unstable.",
+            "order": 146
+          },
+          "dependi.helm.ignoreLinePattern": {
+            "type": "string",
+            "scope": "resource",
+            "default": "",
+            "markdownDescription": "Regex pattern to ignore lines while parsing Chart.yaml dependencies.",
+            "order": 147
+          },
+          "dependi.helm.informPatchUpdates": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": false,
+            "description": "Inform about available patch updates for Helm charts via decoration.",
+            "order": 148
+          },
+          "dependi.helm.silenceVersionOverflows": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": false,
+            "description": "Consider a chart as up-to-date if its version exceeds repository max.",
+            "order": 149
+          }
+        }
+      },
+      {
         "title": "Vulnerability Settings",
         "properties": {
           "dependi.vulnerability.enabled": {
@@ -956,7 +1011,8 @@
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "test-compile": "tsc -p ./",
     "build": "npm run esbuild",
-    "package": "npx vsce package"
+    "package": "npx vsce package",
+    "test-helm": "npx ts-node --project tsconfig.json scripts/test-helm.ts"
   },
   "types": "vscode",
   "devDependencies": {
@@ -973,14 +1029,16 @@
     "eslint": "9.9.0",
     "glob": "11.0.0",
     "mocha": "10.7.3",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "ts-node": "10.9.2"
   },
   "dependencies": {
     "@neuralegion/cvss": "1.2.2",
     "fast-toml": "0.5.4",
     "node-cache": "5.1.2",
     "release-please": "16.12.0",
-    "semver": "7.6.3"
+    "semver": "7.6.3",
+    "yaml": "2.5.0"
   },
   "extensionDependencies": [
     "vscode.git"

--- a/vscode/scripts/test-helm.ts
+++ b/vscode/scripts/test-helm.ts
@@ -1,0 +1,194 @@
+/**
+ * Helm integration test harness (run outside VSCode UI).
+ *
+ * Usage (from vscode/ directory):
+ *   1. Create a Chart.yaml (or use an existing one).
+ *   2. Run:
+ *        npm run test-helm
+ *      (optionally pass a path: `CHART=../some/Chart.yaml npm run test-helm`)
+ *
+ * This script:
+ *  - Mocks the 'vscode' module at runtime (so we can reuse existing parser/fetcher code).
+ *  - Parses Chart.yaml dependencies via HelmChartParser.
+ *  - Fetches available versions via HelmFetcher (downloads index.yaml from each repository).
+ *  - Prints a small report including current & latest versions.
+ */
+
+// ------------------------------ VSCode Runtime Mock ------------------------------
+/* eslint-disable @typescript-eslint/no-var-requires */
+const Module = require("module");
+const originalLoad = Module._load;
+Module._load = function (request: string, parent: any, isMain: boolean) {
+  // Skip loading unrelated fetchers to avoid circular or unnecessary dependency initialization in headless mode
+  if (/CratesFetcher|NpmFetcher|GoProxyFetcher|PackagistFetcher|PypiFetcher|PubDevFetcher|DependiFetcher/.test(request)) {
+    return {};
+  }
+  if (request === "vscode") {
+    // Minimal Range mock used by Item
+    class Range {
+      start: { line: number; character: number };
+      end: { line: number; character: number };
+      constructor(sl: number, sc: number, el: number, ec: number) {
+        this.start = { line: sl, character: sc };
+        this.end = { line: el, character: ec };
+      }
+    }
+    // Minimal StatusBarItem mock
+    class StatusBarItemMock {
+      text = "";
+      tooltip: string | undefined;
+      color: string | undefined;
+      command: any;
+      show() {}
+      hide() {}
+    }
+    return {
+      // Only what our code touches
+      workspace: { getConfiguration: () => ({ get: () => undefined }) },
+      env: { isTelemetryEnabled: false },
+      commands: {
+        executeCommand: () => Promise.resolve(),
+        registerTextEditorCommand: () => ({ dispose() {} }),
+        registerCommand: () => ({ dispose() {} })
+      },
+      window: {
+        createStatusBarItem: () => new StatusBarItemMock(),
+        setStatusBarMessage: () => ({ dispose() {} }),
+        showErrorMessage: () => {}
+      },
+      StatusBarAlignment: { Left: 1, Right: 2 },
+      Range,
+      TextDocument: class {}
+    };
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+// ------------------------------ Imports (after mock) ------------------------------
+import { readFileSync } from "fs";
+import { existsSync } from "fs";
+import { join, resolve } from "path";
+import { HelmChartParser } from "../src/core/parsers/HelmChartParser";
+import { HelmFetcher } from "../src/core/fetchers/HelmFetcher";
+import Dependency from "../src/core/Dependency";
+import Item from "../src/core/Item";
+
+// We rely on default Settings object (do not call Settings.load() since it queries real VSCode config).
+
+// ------------------------------ Minimal TextDocument Mock ------------------------------
+interface TextLine {
+  text: string;
+  lineNumber: number;
+  firstNonWhitespaceCharacterIndex: number;
+  range: { end: { character: number } };
+}
+class MockTextDocument {
+  private lines: string[];
+  constructor(public content: string) {
+    this.lines = content.split(/\r?\n/);
+  }
+  get lineCount() {
+    return this.lines.length;
+  }
+  lineAt(i: number): TextLine {
+    const text = this.lines[i];
+    return {
+      text,
+      lineNumber: i,
+      firstNonWhitespaceCharacterIndex: (text.match(/^(\s*)/)?.[1].length as number) || 0,
+      range: { end: { character: text.length } }
+    };
+  }
+  getText(): string {
+    return this.content;
+  }
+}
+
+// ------------------------------ Helpers ------------------------------
+function pickChartPath(): string {
+  // Priority order:
+  // 1. CHART environment variable
+  // 2. Local ./Chart.yaml
+
+  if (process.env.CHART) {
+    const abs = resolve(process.env.CHART);
+    if (existsSync(abs)) return abs;
+    throw new Error(`Provided chart path not found: ${abs}\nUsage examples:\n  CHART=/abs/path/Chart.yaml npm run test-helm`);
+  }
+
+  const local = join(process.cwd(), "Chart.yaml");
+  if (existsSync(local)) return local;
+
+  throw new Error("Chart.yaml not found.\nProvide a path via one of:\n  CHART=/abs/path/Chart.yaml npm run test-helm");
+}
+
+function printHeader(msg: string) {
+  console.log("\n=== " + msg + " ===");
+}
+
+// ------------------------------ Main Flow ------------------------------
+process.env.DEPENDI_HEADLESS = "1";
+
+async function main() {
+  const chartPath = pickChartPath();
+  printHeader("Helm Test Harness");
+  console.log("Chart file:", chartPath);
+
+  const content = readFileSync(chartPath, "utf8");
+  const doc = new MockTextDocument(content) as any;
+
+  const parser = new HelmChartParser();
+  const items: Item[] = parser.parse(doc);
+
+  if (!items.length) {
+    console.warn("No dependencies parsed from Chart.yaml");
+    return;
+  }
+
+  printHeader("Parsed Dependencies");
+  items.forEach((it) =>
+    console.log({
+      key: it.key,
+      chartName: it.chartName,
+      repository: it.repository,
+      currentVersion: it.value,
+      line: it.line
+    })
+  );
+
+  const deps = items.map((i) => new Dependency(i));
+
+  const fetcher = new HelmFetcher();
+  const runner = fetcher.fetch();
+
+  printHeader("Resolving Versions (index.yaml fetch)");
+  for (const dep of deps) {
+    await runner(dep);
+    console.log({
+      key: dep.item.key,
+      current: dep.item.value,
+      latest: dep.item.latestVersion,
+      sampleVersions: dep.versions?.slice(0, 5),
+      totalVersions: dep.versions?.length,
+      error: dep.error
+    });
+  }
+
+  printHeader("Summary");
+  const updatable = deps.filter((d) => d.item.latestVersion && d.item.value && d.item.latestVersion !== d.item.value);
+  console.log("Total deps:", deps.length);
+  console.log("Updatable:", updatable.length);
+  if (updatable.length) {
+    console.log(
+      "Updates:",
+      updatable.map((d) => `${d.item.key}: ${d.item.value} -> ${d.item.latestVersion}`)
+    );
+  } else {
+    console.log("All dependencies appear up-to-date or errors occurred.");
+  }
+}
+
+main().catch((e) => {
+  console.error("Harness failed:", e);
+  process.exit(1);
+});

--- a/vscode/src/api/indexes/dependi/reports.ts
+++ b/vscode/src/api/indexes/dependi/reports.ts
@@ -39,6 +39,7 @@ export enum Language {
   Python,
   PHP,
   Dart,
+  Helm
 }
 
 const LanguageArray = [
@@ -47,6 +48,7 @@ const LanguageArray = [
   { ID: Language.JS, Name: "package.json" },
   { ID: Language.PHP, Name: "composer.json" },
   { ID: Language.Python, Name: "requirements.txt" },
+  { ID: Language.Helm, Name: "Chart.yaml" }
 ];
 
 export const getLangIdFromName = (name: string): Language => LanguageArray.find((lang) => lang.Name === name)?.ID ?? Language.None;
@@ -57,10 +59,10 @@ export async function getVulnReport(req: VulnReq, options?: RequestInit) {
     headers: {
       Authorization: Settings.api.key,
       "X-Device-ID": Settings.api.deviceID,
-      "Content-Type": "application/json",
+      "Content-Type": "application/json"
     },
     body: JSON.stringify(req),
-    ...options,
+    ...options
   });
   return response;
 }
@@ -71,10 +73,10 @@ export async function getCurrentVulnReport(req: VulnReq, options?: RequestInit) 
     headers: {
       Authorization: Settings.api.key,
       "X-Device-ID": Settings.api.deviceID,
-      "Content-Type": "application/json",
+      "Content-Type": "application/json"
     },
     body: JSON.stringify(req),
-    ...options,
+    ...options
   });
   return response;
 }
@@ -86,8 +88,8 @@ export async function getReportPDF(req: string, options?: RequestInit) {
     headers: {
       Authorization: Settings.api.key,
       "X-Device-ID": Settings.api.deviceID,
-      "Content-Type": "application/json",
+      "Content-Type": "application/json"
     },
-    ...options,
+    ...options
   });
 }

--- a/vscode/src/config.ts
+++ b/vscode/src/config.ts
@@ -58,6 +58,12 @@ export enum Configs {
   DART_ENABLED_LOCK_FILE = `dart.lockFileEnabled`,
   DART_SILENCE_VERSION_OVERFLOWS = `dart.silenceVersionOverflows`,
 
+  HELM_ENABLED = `helm.enabled`,
+  HELM_UNSTABLE_FILTER = `helm.unstableFilter`,
+  HELM_IGNORE_LINE_PATTERN = `helm.ignoreLinePattern`,
+  HELM_INFORM_PATCH_UPDATES = `helm.informPatchUpdates`,
+  HELM_SILENCE_VERSION_OVERFLOWS = `helm.silenceVersionOverflows`,
+
   VULS_ENABLED = `vulnerability.enabled`,
   VULS_GHSA_ENABLED = `vulnerability.ghsa.enabled`,
   VULS_OSV_BATCH_URL = `vulnerability.osvQueryURL.batch`,
@@ -65,7 +71,6 @@ export enum Configs {
 
   INDEX_SERVER_API_KEY = `apiKey`,
   INDEX_SERVER_URL = `apiURL`,
-
 
   DECORATOR_POSITION = `decoration.position`,
 
@@ -93,12 +98,11 @@ export enum Configs {
   // Extras
   SILENCE_UPDATE_MESSAGES = `extras.silenceUpdateMessages`,
 
-
   //Storage
   DEVICE_ID = `${DEPENDI}deviceID`,
   SHOWN_VERSION = `${DEPENDI}shownVersion`,
 
-  // Old Settings 
+  // Old Settings
   RUST_UNSTABLE_OLD = `rust.excludeUnstableVersions`,
   NPM_UNSTABLE_OLD = `npm.excludeUnstableVersions`,
   PHP_UNSTABLE_OLD = `php.excludeUnstableVersions`,
@@ -161,6 +165,13 @@ export const Settings = {
     lockFileEnabled: true,
     silenceVersionOverflows: false
   },
+  helm: {
+    enabled: true,
+    unstableFilter: UnstableFilter.Exclude,
+    ignoreLinePattern: "",
+    informPatchUpdates: false,
+    silenceVersionOverflows: false
+  },
   vulnerability: {
     enabled: false,
     ghsa: false,
@@ -172,7 +183,6 @@ export const Settings = {
     url: "",
     proPanelURL: "https://www.dependi.io/pro",
     deviceID: ""
-
   },
   decorator: {
     position: "" as DecorationPosition,
@@ -211,7 +221,7 @@ export const Settings = {
     this.rust.informPatchUpdates = config.get<boolean>(Configs.RUST_INFORM_PATCH_UPDATES) ?? false;
     this.rust.lockFileEnabled = config.get<boolean>(Configs.RUST_ENABLED_LOCK_FILE) ?? true;
     this.rust.silenceVersionOverflows = config.get<boolean>(Configs.RUST_SILENCE_VERSION_OVERFLOWS) ?? false;
-    
+
     this.npm.enabled = config.get<boolean>(Configs.NPM_ENABLED) ?? true;
     this.npm.index = config.get<string>(Configs.NPM_INDEX_SERVER_URL) || "https://registry.npmjs.org";
     this.npm.unstableFilter = migrateUnstableSettings(Configs.NPM_UNSTABLE_FILTER, Configs.NPM_UNSTABLE_OLD);
@@ -251,6 +261,12 @@ export const Settings = {
     this.dart.lockFileEnabled = config.get<boolean>(Configs.DART_ENABLED_LOCK_FILE) ?? true;
     this.dart.silenceVersionOverflows = config.get<boolean>(Configs.DART_SILENCE_VERSION_OVERFLOWS) ?? false;
 
+    this.helm.enabled = config.get<boolean>(Configs.HELM_ENABLED) ?? true;
+    this.helm.unstableFilter = migrateUnstableSettings(Configs.HELM_UNSTABLE_FILTER, Configs.HELM_UNSTABLE_FILTER);
+    this.helm.ignoreLinePattern = config.get<string>(Configs.HELM_IGNORE_LINE_PATTERN) || "";
+    this.helm.informPatchUpdates = config.get<boolean>(Configs.HELM_INFORM_PATCH_UPDATES) ?? false;
+    this.helm.silenceVersionOverflows = config.get<boolean>(Configs.HELM_SILENCE_VERSION_OVERFLOWS) ?? false;
+
     this.vulnerability.enabled = config.get<boolean>(Configs.VULS_ENABLED) ?? true;
     this.vulnerability.ghsa = config.get<boolean>(Configs.VULS_GHSA_ENABLED) ?? false;
     this.vulnerability.osvBatch = config.get<string>(Configs.VULS_OSV_BATCH_URL) || "https://api.osv.dev/v1/querybatch";
@@ -282,7 +298,7 @@ export const Settings = {
   }
 };
 
-function migrateUnstableSettings(newSettingKey: string , oldSettingKey: string): UnstableFilter {
+function migrateUnstableSettings(newSettingKey: string, oldSettingKey: string): UnstableFilter {
   const config = workspace.getConfiguration("dependi");
   const filter = config.get<string>(newSettingKey);
   if (Settings.version > "0.7.9") {

--- a/vscode/src/core/Item.ts
+++ b/vscode/src/core/Item.ts
@@ -4,8 +4,6 @@ import { Range } from "vscode";
  * Item is a data structure to define parsed items, hierarchy and index.
  */
 
-
-
 export default class Item {
   key: string = "";
   value: string | undefined = "";
@@ -17,6 +15,8 @@ export default class Item {
   decoRange: Range = new Range(0, 0, 0, 0);
   lockedAt?: string;
   latestVersion?: string;
+  repository?: string; // Helm: repository URL
+  chartName?: string; // Helm: original chart name if alias used
   constructor(item?: Item) {
     if (item) {
       this.key = item.key;
@@ -42,21 +42,11 @@ export default class Item {
 
   /**Create Range */
   createRange() {
-    this.range = new Range(
-      this.line,
-      this.start,
-      this.line,
-      this.end
-    );
+    this.range = new Range(this.line, this.start, this.line, this.end);
   }
   /**Create Decoration Range */
   createDecoRange() {
-    this.decoRange = new Range(
-      this.line,
-      this.start,
-      this.line,
-      this.endOfLine
-    );
+    this.decoRange = new Range(this.line, this.start, this.line, this.endOfLine);
   }
 
   isValid() {

--- a/vscode/src/core/Language.ts
+++ b/vscode/src/core/Language.ts
@@ -1,69 +1,72 @@
-import path from 'path';
-import { sendTelemetry } from '../api/telemetry/telemetry';
-import { commands, env } from 'vscode';
-import { Settings } from '../config';
+import path from "path";
+import { sendTelemetry } from "../api/telemetry/telemetry";
+import { commands, env } from "vscode";
+import { Settings } from "../config";
 
 export enum Language {
-    None = 0,
-    Rust = 1,
-    Golang = 2,
-    JS = 3,
-    Python = 4,
-    PHP = 5,
-    Dart = 6,
+  None = 0,
+  Rust = 1,
+  Golang = 2,
+  JS = 3,
+  Python = 4,
+  PHP = 5,
+  Dart = 6,
+  Helm = 7
 }
 
 export enum OCVEnvironment {
-    Cratesio = "crates.io",
-    Npm = "npm",
-    Packagist = "Packagist",
-    Pypi = "PyPI",
-    Go = "Go",
-    Dart = "Pub",
+  Cratesio = "crates.io",
+  Npm = "npm",
+  Packagist = "Packagist",
+  Pypi = "PyPI",
+  Go = "Go",
+  Dart = "Pub",
+  Helm = "Helm"
 }
 export var CurrentLanguage: Language = Language.None;
 export var CurrentLanguageConfig: string = "";
 export var CurrentEnvironment: OCVEnvironment = OCVEnvironment.Cratesio;
 
 export function setLanguage(file?: string) {
-    if (!file) {
-        CurrentLanguage = Language.None;
-        return;
-    }
-    const filename = path.basename(file);
-    const fileExtension = path.extname(filename);
-    switch (filename.toLowerCase()) {
-        case "cargo.toml":
-            return setLanguageConfig(Language.Rust, "rust", filename, OCVEnvironment.Cratesio, Settings.rust.lockFileEnabled);
-        case "go.mod":
-            return setLanguageConfig(Language.Golang, "go", filename, OCVEnvironment.Go);
-        case "package.json":
-            return setLanguageConfig(Language.JS, "npm", filename, OCVEnvironment.Npm, Settings.npm.lockFileEnabled);
-        case "composer.json":
-            return setLanguageConfig(Language.PHP, "php", filename, OCVEnvironment.Packagist, Settings.php.lockFileEnabled);
-        case "pyproject.toml":
-            return setLanguageConfig(Language.Python, "python", filename, OCVEnvironment.Pypi, Settings.python.lockFileEnabled);
-        case "pixi.toml":
-            return setLanguageConfig(Language.Python, "python", filename, OCVEnvironment.Pypi, Settings.python.lockFileEnabled);
-        case "pubspec.yaml":
-            return setLanguageConfig(Language.Dart, "dart", filename, OCVEnvironment.Dart);    
-        default:
-            if ((fileExtension === ".txt" || fileExtension === ".in") &&  filename.toLowerCase().startsWith("requirement")) {
-                return setLanguageConfig(Language.Python, "python", filename, OCVEnvironment.Pypi, Settings.python.lockFileEnabled);
-            }
-    }
-};
+  if (!file) {
+    CurrentLanguage = Language.None;
+    return;
+  }
+  const filename = path.basename(file);
+  const fileExtension = path.extname(filename);
+  switch (filename.toLowerCase()) {
+    case "cargo.toml":
+      return setLanguageConfig(Language.Rust, "rust", filename, OCVEnvironment.Cratesio, Settings.rust.lockFileEnabled);
+    case "go.mod":
+      return setLanguageConfig(Language.Golang, "go", filename, OCVEnvironment.Go);
+    case "package.json":
+      return setLanguageConfig(Language.JS, "npm", filename, OCVEnvironment.Npm, Settings.npm.lockFileEnabled);
+    case "composer.json":
+      return setLanguageConfig(Language.PHP, "php", filename, OCVEnvironment.Packagist, Settings.php.lockFileEnabled);
+    case "pyproject.toml":
+      return setLanguageConfig(Language.Python, "python", filename, OCVEnvironment.Pypi, Settings.python.lockFileEnabled);
+    case "pixi.toml":
+      return setLanguageConfig(Language.Python, "python", filename, OCVEnvironment.Pypi, Settings.python.lockFileEnabled);
+    case "pubspec.yaml":
+      return setLanguageConfig(Language.Dart, "dart", filename, OCVEnvironment.Dart);
+    case "chart.yaml":
+      return setLanguageConfig(Language.Helm, "helm", filename, OCVEnvironment.Helm);
+    default:
+      if ((fileExtension === ".txt" || fileExtension === ".in") && filename.toLowerCase().startsWith("requirement")) {
+        return setLanguageConfig(Language.Python, "python", filename, OCVEnvironment.Pypi, Settings.python.lockFileEnabled);
+      }
+  }
+}
 
 function setLanguageConfig(language: Language, config: string, filename: string, OCVenv: OCVEnvironment, isLockFileEnabled?: boolean) {
-    CurrentLanguage = language;
-    CurrentLanguageConfig = config;
-    CurrentEnvironment = OCVenv;
-    commands.executeCommand("setContext", "dependi.supportedFiles", [filename]);
-    if (env.isTelemetryEnabled) 
-        sendTelemetry({FileName: filename})
-    if (isLockFileEnabled !== undefined) {
-        commands.executeCommand("setContext", "dependi.hasLockFile", false);
-        commands.executeCommand("setContext", "dependi.isEnableLockParsing", isLockFileEnabled);
-    }
-    return language;
+  CurrentLanguage = language;
+  CurrentLanguageConfig = config;
+  CurrentEnvironment = OCVenv;
+  commands.executeCommand("setContext", "dependi.supportedFiles", [filename]);
+  if (env.isTelemetryEnabled) sendTelemetry({ FileName: filename });
+  if (isLockFileEnabled !== undefined) {
+    commands.executeCommand("setContext", "dependi.hasLockFile", false);
+    commands.executeCommand("setContext", "dependi.isEnableLockParsing", isLockFileEnabled);
+  }
+  return language;
 }

--- a/vscode/src/core/fetchers/HelmFetcher.ts
+++ b/vscode/src/core/fetchers/HelmFetcher.ts
@@ -1,0 +1,116 @@
+import * as https from "https";
+import { parse } from "yaml";
+import Dependency from "../Dependency";
+import { Fetcher } from "./fetcher";
+import compareVersions from "../../semver/compareVersions";
+import { Settings, UnstableFilter } from "../../config";
+
+/**
+ * HelmFetcher downloads index.yaml from each dependency's repository
+ * and extracts available chart versions.
+ */
+export class HelmFetcher extends Fetcher {
+  // repository index cache (in-memory, simple TTL)
+  private static repoCache: Map<string, { ts: number; content: string }> =
+    new Map();
+  private ttlMs = 5 * 60 * 1000;
+
+  constructor() {
+    // pass non-empty dummy values to avoid settings dialog in Fetcher
+    super("helm", "helm.index");
+  }
+
+  fetch(): (i: Dependency) => Promise<Dependency> {
+    const base = this;
+    return async function (dep: Dependency): Promise<Dependency> {
+      console.log("Fetching versions for", dep.item.key);
+      if (!dep.item.repository) {
+        dep.error = "Missing repository";
+        return dep;
+      }
+      try {
+        const indexContent = await base.getIndexYaml(dep.item.repository);
+
+        const versions = base
+          .extractChartVersions(
+            indexContent,
+            dep.item.chartName || dep.item.key
+          )
+          .filter(
+            (v) =>
+              v &&
+              !base.checkUnstables(
+                Settings.helm.unstableFilter as UnstableFilter,
+                v,
+                dep.item.value || v
+              )
+          )
+          .sort(compareVersions)
+          .reverse();
+        if (versions.length === 0) {
+          dep.error = dep.error || "No versions found";
+        } else {
+          dep.versions = versions;
+          dep.item.latestVersion = versions[0];
+        }
+      } catch (e: any) {
+        dep.error = e?.message || "Failed to fetch index.yaml";
+      }
+      return dep;
+    };
+  }
+
+  private async getIndexYaml(repo: string): Promise<string> {
+    const url = repo + "/index.yaml";
+    const cached = HelmFetcher.repoCache.get(url);
+    const now = Date.now();
+    if (cached && now - cached.ts < this.ttlMs) {
+      return cached.content;
+    }
+    const content = await this.httpGet(url);
+    HelmFetcher.repoCache.set(url, { ts: now, content });
+    return content;
+  }
+
+  private httpGet(url: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      https
+        .get(url, (res) => {
+          if (
+            !res.statusCode ||
+            res.statusCode < 200 ||
+            res.statusCode >= 300
+          ) {
+            reject(new Error(`HTTP ${res.statusCode} ${url}`));
+            return;
+          }
+          let data = "";
+          res.on("data", (c) => (data += c.toString("utf8")));
+          res.on("end", () => resolve(data));
+        })
+        .on("error", reject);
+    });
+  }
+
+  /**
+   * Extract chart versions from index.yaml content.
+   */
+  private extractChartVersions(
+    indexContent: string,
+    chartName: string
+  ): string[] {
+    try {
+      const data: any = parse(indexContent);
+      if (!data) return [];
+      // Standard Helm index: entries: { chartName: [ { version: "x" }, ... ] }
+      const entryArray = data?.entries?.[chartName] || data?.[chartName]; // fallback if some index omits 'entries'
+      if (!Array.isArray(entryArray)) return [];
+      const versions = entryArray
+        .map((o) => (o && typeof o === "object" ? o.version : undefined))
+        .filter((v) => typeof v === "string" && v.length > 0);
+      return Array.from(new Set(versions));
+    } catch {
+      return [];
+    }
+  }
+}

--- a/vscode/src/core/listeners/HelmListener.ts
+++ b/vscode/src/core/listeners/HelmListener.ts
@@ -1,0 +1,49 @@
+import { TextEditor } from "vscode";
+import { Settings } from "../../config";
+import decorate from "../../ui/decorator";
+import Dependency from "../Dependency";
+import { CurrentLanguage, Language } from "../Language";
+import { Fetcher } from "../fetchers/fetcher";
+import { Parser } from "../parsers/parser";
+import { Listener } from "./listener";
+import { status } from "../../commands/replacers";
+import { StatusBar } from "../../ui/status-bar";
+
+/**
+ * HelmListener overrides vulnerability fetching (none for Helm) and only resolves versions.
+ */
+export class HelmListener extends Listener {
+  constructor(fetcher: Fetcher, parser: Parser) {
+    super(fetcher, parser);
+  }
+
+  async parseAndDecorate(editor: TextEditor) {
+    try {
+      let dependencies: Dependency[] = this.parse(editor);
+
+      // Only fetch versions (no vulnerability queries for Helm)
+      await this.fetcher.versions(dependencies);
+
+      status.updateAllData = dependencies.map((d) => ({
+        key: d.item.key,
+        version: this.buildVersionWithPrefix(d),
+        startLine: d.item.range.start.line,
+      }));
+
+      decorate(editor, dependencies, CurrentLanguage);
+    } catch (e) {
+      console.error(e);
+      StatusBar.setText("Error", "Helm processing failed");
+    } finally {
+      status.inProgress = false;
+    }
+  }
+}
+
+// Convenience factory (if needed elsewhere)
+export function createHelmListener(
+  fetcher: Fetcher,
+  parser: Parser
+): HelmListener {
+  return new HelmListener(fetcher, parser);
+}

--- a/vscode/src/core/parsers/HelmChartParser.ts
+++ b/vscode/src/core/parsers/HelmChartParser.ts
@@ -1,0 +1,187 @@
+import { TextDocument } from "vscode";
+import Item from "../Item";
+import { Parser } from "./parser";
+import { Settings } from "../../config";
+import { parseDocument, YAMLMap, YAMLSeq, Scalar, isAlias } from "yaml";
+
+/**
+ * HelmChartParser (YAML based)
+ * Parses Chart.yaml dependencies using the 'yaml' package (eemeli/yaml).
+ *
+ * Supported dependency entry forms:
+ * dependencies:
+ *  - name: nginx
+ *    version: 15.10.0
+ *    repository: https://charts.bitnami.com/bitnami
+ *    alias: web
+ *
+ *  - { name: redis, version: 17.1.0, repository: "https://charts.bitnami.com/bitnami" }
+ *
+ * We require name + version + repository to emit an Item.
+ * Alias is optional (used as display key if present).
+ */
+export class HelmChartParser implements Parser {
+  parse(doc: TextDocument): Item[] {
+    const items: Item[] = [];
+    if (!doc) return items;
+
+    // Acquire full text (supports VSCode TextDocument & test harness mock)
+    const text = (doc as any).getText?.() || buildTextFromLines(doc); // fallback (should rarely happen after harness update)
+
+    // Precompute line start offsets for offset->(line,char) mapping
+    const lineStarts = computeLineStarts(text);
+
+    const ydoc = parseDocument(text);
+
+    if (ydoc.errors && ydoc.errors.length) {
+      // Strict: on YAML structural errors return empty (no fallback legacy parser)
+      return items;
+    }
+
+    const depsNode = ydoc.get("dependencies", true);
+    if (!depsNode || !(depsNode instanceof YAMLSeq)) {
+      return items;
+    }
+
+    for (let entry of depsNode.items) {
+      if (!entry) continue;
+
+      if (isAlias(entry)) {
+        // Resolve alias target if possible
+        entry = entry.resolve(ydoc) as any;
+      }
+      if (!(entry instanceof YAMLMap)) continue;
+
+      const nameInfo = getScalar(entry, "name");
+      const versionInfo = getScalar(entry, "version");
+      const repoInfo = getScalar(entry, "repository");
+      const aliasInfo = getScalar(entry, "alias");
+
+      if (!nameInfo?.value || !versionInfo?.value || !repoInfo?.value) {
+        continue;
+      }
+
+      const versionNode = versionInfo.node;
+      if (!versionNode || !Array.isArray((versionNode as any).range)) {
+        continue;
+      }
+      const [startOffset, endOffset] = (versionNode as any).range as [
+        number,
+        number
+      ];
+
+      const startPos = offsetToPos(startOffset, lineStarts);
+      const endPos = offsetToPos(endOffset, lineStarts);
+
+      const item = new Item();
+      item.key = aliasInfo?.value || nameInfo.value;
+      item.chartName = nameInfo.value;
+      item.repository = normalizeRepo(repoInfo.value);
+      item.value = versionInfo.value;
+
+      // Fill positional metadata
+      item.line = startPos.line;
+      item.start = startPos.character;
+      item.end = endPos.character;
+      const lineText = safeLineText(doc, item.line);
+      item.endOfLine = lineText.length;
+
+      // Ignore via regex pattern if configured (evaluate against trimmed line text)
+      if (shouldIgnoreLine(lineText)) {
+        continue;
+      }
+
+      item.createRange();
+      item.createDecoRange();
+      if (item.isValid()) {
+        items.push(item);
+      }
+    }
+
+    return items;
+  }
+}
+
+/* ------------------------------ Helpers ------------------------------ */
+
+function getScalar(
+  map: YAMLMap,
+  key: string
+): { value: string; node: Scalar } | null {
+  const node = map.get(key, true) as any;
+  if (!node) return null;
+  if (node instanceof Scalar) {
+    if (node.value === null || node.value === undefined) return null;
+    return { value: String(node.value), node };
+  }
+  return null;
+}
+
+function buildTextFromLines(doc: TextDocument): string {
+  const lines: string[] = [];
+  for (let i = 0; i < doc.lineCount; i++) {
+    lines.push(doc.lineAt(i).text);
+  }
+  return lines.join("\n");
+}
+
+function computeLineStarts(text: string): number[] {
+  const starts: number[] = [0];
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) {
+      starts.push(i + 1);
+    }
+  }
+  return starts;
+}
+
+function offsetToPos(
+  offset: number,
+  lineStarts: number[]
+): { line: number; character: number } {
+  // Binary search
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    const lineStart = lineStarts[mid];
+    const nextLineStart =
+      mid + 1 < lineStarts.length ? lineStarts[mid + 1] : Infinity;
+    if (offset >= lineStart && offset < nextLineStart) {
+      return { line: mid, character: offset - lineStart };
+    } else if (offset < lineStart) {
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+  // Fallback
+  const last = lineStarts[lineStarts.length - 1];
+  return { line: lineStarts.length - 1, character: Math.max(0, offset - last) };
+}
+
+function safeLineText(doc: TextDocument, line: number): string {
+  if (line < 0 || line >= doc.lineCount) return "";
+  return doc.lineAt(line).text;
+}
+
+function shouldIgnoreLine(lineText: string): boolean {
+  const trimmed = lineText.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith("#")) return true;
+  if (Settings.helm?.ignoreLinePattern) {
+    try {
+      const r = new RegExp(Settings.helm.ignoreLinePattern);
+      if (r.test(trimmed)) return true;
+    } catch {
+      // ignore invalid pattern
+    }
+  }
+  return false;
+}
+
+function normalizeRepo(repo: string): string {
+  let r = repo.trim();
+  if (r.endsWith("/")) r = r.slice(0, -1);
+  return r;
+}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -2,14 +2,7 @@
 /**
  * This extension helps to manage crate dependency versions.
  */
-import {
-  commands,
-  ExtensionContext,
-  OutputChannel,
-  TextDocumentChangeEvent,
-  window,
-  workspace,
-} from "vscode";
+import { commands, ExtensionContext, OutputChannel, TextDocumentChangeEvent, window, workspace } from "vscode";
 import { replaceVersion } from "./commands/replacers/replaceVersion";
 import { updateAll } from "./commands/replacers/updateAll";
 import { generateCurrentVulnReport } from "./commands/report-generator/generateCurrentVulnReport";
@@ -25,7 +18,6 @@ import { disableLockFileParsing } from "./commands/lock-file/disableLockFilePars
 import { enableLockFileParsing } from "./commands/lock-file/enableLockFileParsing";
 import { lockFileParsed } from "./commands/lock-file/lockFileParsed";
 import { DependencyCache } from "./core/listeners/listener";
-
 
 export var Logger: OutputChannel;
 
@@ -99,12 +91,12 @@ export function activate(context: ExtensionContext) {
     "composer.json",
     "requirements.txt",
     "requirements-dev.txt",
-    "pyproject.toml",
+    "pyproject.toml"
   ]);
 
   console.debug("Adding commands");
   context.subscriptions.push(retry);
-  context.subscriptions.push(replaceVersion);
+  context.subscriptions.push(replaceVersion as any);
   context.subscriptions.push(updateAll);
   context.subscriptions.push(generateVulnerabilityReport(context));
   context.subscriptions.push(generateCurrentVulnReport(context));
@@ -131,11 +123,7 @@ async function configure(context: ExtensionContext) {
     Logger.appendLine("Updated version");
     if (!Settings.extras.silenceUpdateMessages) {
       window
-        .showInformationMessage(
-          "Dependi has been updated to a new version. See the CHANGELOG!",
-          "Show Changelog",
-          "Dismiss"
-        )
+        .showInformationMessage("Dependi has been updated to a new version. See the CHANGELOG!", "Show Changelog", "Dismiss")
         .then((selection) => {
           if (selection === "Show Changelog") {
             ChangelogPanel.render(context);

--- a/vscode/src/semver/semverUtils.ts
+++ b/vscode/src/semver/semverUtils.ts
@@ -2,7 +2,6 @@ import { compare, gt, maxSatisfying, minVersion, satisfies } from "semver";
 import { Settings } from "../config";
 import { CurrentLanguage, Language } from "../core/Language";
 
-
 export function checkVersion(version: string = "0.0.0", versions: string[], lockedAt?: string): [boolean, boolean, string | null] {
   let v = versionToSemver(version, true);
 
@@ -45,8 +44,11 @@ export function checkVersion(version: string = "0.0.0", versions: string[], lock
     case Language.Python:
       shouldPatchBeChecked = Settings.python.informPatchUpdates;
       break;
+    case Language.Helm:
+      shouldPatchBeChecked = Settings.helm.informPatchUpdates;
+      break;
   }
-  const pathUpdated = shouldPatchBeChecked ? compare(max, minVersion(v) ?? '0.0.0') === 1 : false;
+  const pathUpdated = shouldPatchBeChecked ? compare(max, minVersion(v) ?? "0.0.0") === 1 : false;
   const maxSatisfyingVersion = maxSatisfying(semverVersions, v);
   if (maxSatisfyingVersion && CurrentLanguage === Language.Python) {
     return [satisfies(max, v), pathUpdated, versionMap[maxSatisfyingVersion]];
@@ -65,7 +67,7 @@ function mapVersions(versions: string[], semverVersions: string[]): Record<strin
 
 function ensureCaretPrefix(version: string): string {
   const prefix = version.charCodeAt(0);
-  return (prefix > 47 && prefix < 58) ? `^${version}` : version;
+  return prefix > 47 && prefix < 58 ? `^${version}` : version;
 }
 
 function checkLockedVersion(lockedAt: string, version: string, semverVersions: string[]): [boolean, boolean, string | null] | null {
@@ -90,7 +92,7 @@ function normalizeVersion(version: string, isCurrentVersion?: boolean): string {
   // count the number of dots in the version string
   let dotCount = 0;
   for (let i = 0; i < version.length; i++) {
-    if (version[i] === '.') {
+    if (version[i] === ".") {
       dotCount++;
       if (dotCount > 1) {
         return version;
@@ -107,15 +109,15 @@ function normalizeVersion(version: string, isCurrentVersion?: boolean): string {
 
 function convertPythonVersion(version: string): string {
   return version
-      .replace(/\.dev(\d+)/, '-dev.$1')
-      .replace(/\.post(\d+)/, '-post.$1')
-      .replace(/\.a(\d+)/, '-alpha.$1')
-      .replace(/\.b(\d+)/, '-beta.$1')
-      .replace(/\.rc(\d+)/, '-rc.$1')
-      .replace(/a(\d+)/, '-alpha.$1')
-      .replace(/b(\d+)/, '-beta.$1')
-      .replace(/rc(\d+)/, '-rc.$1')
-      .replace(/c(\d+)/, '-c.$1')
+    .replace(/\.dev(\d+)/, "-dev.$1")
+    .replace(/\.post(\d+)/, "-post.$1")
+    .replace(/\.a(\d+)/, "-alpha.$1")
+    .replace(/\.b(\d+)/, "-beta.$1")
+    .replace(/\.rc(\d+)/, "-rc.$1")
+    .replace(/a(\d+)/, "-alpha.$1")
+    .replace(/b(\d+)/, "-beta.$1")
+    .replace(/rc(\d+)/, "-rc.$1")
+    .replace(/c(\d+)/, "-c.$1");
 }
 
 export function convertPythonVersionToSemver(version: string): string {
@@ -127,7 +129,7 @@ export function convertPythonVersionToSemver(version: string): string {
     const major = match[1];
     const minor = match[2];
     const patch = match[3] || 0;
-    const preRelease = match[4]? `-${match[4].slice(1)}`  :"";
+    const preRelease = match[4] ? `-${match[4].slice(1)}` : "";
 
     const normalizedVersion = `${major}.${minor}.${patch}${preRelease}`;
     return normalizedVersion;
@@ -150,6 +152,8 @@ function treatAsUpToDate(): boolean {
       return Settings.python.silenceVersionOverflows;
     case Language.Dart:
       return Settings.dart.silenceVersionOverflows;
+    case Language.Helm:
+      return Settings.helm.silenceVersionOverflows;
   }
   return false;
 }

--- a/vscode/src/ui/status-bar.ts
+++ b/vscode/src/ui/status-bar.ts
@@ -14,10 +14,21 @@ interface StatusBarItemExt extends StatusBarItem {
   fetching: (indexServerURL: string) => void;
 }
 
-export const StatusBar: StatusBarItemExt = window.createStatusBarItem(
-  StatusBarAlignment.Right,
-  -1000
+const __safeVSCodeWindow: any = (typeof window !== "undefined" && (window as any)) || {};
+const __rawStatusBarItem = (
+  __safeVSCodeWindow.createStatusBarItem
+    ? __safeVSCodeWindow.createStatusBarItem(StatusBarAlignment.Right, -1000)
+    : {
+        text: "",
+        tooltip: "",
+        color: "",
+        command: undefined,
+        show() {},
+        hide() {}
+      }
 ) as StatusBarItemExt;
+
+export const StatusBar: StatusBarItemExt = __rawStatusBarItem;
 StatusBar.setText = (t: Type, text?: string, noDialog: boolean = false) => {
   switch (t) {
     case "Error":
@@ -53,9 +64,9 @@ StatusBar.setText = (t: Type, text?: string, noDialog: boolean = false) => {
 StatusBar.fetching = (indexServerURL: string) => {
   StatusBar.color = "statusBarItem.activeForeground";
   StatusBar.text = "$(sync~spin) Dependi";
-  StatusBar.tooltip = "👀 Fetching " + indexServerURL.replace(/^https?:\/\//, '');
+  StatusBar.tooltip = "👀 Fetching " + indexServerURL.replace(/^https?:\/\//, "");
   StatusBar.command = Configs.RETRY;
 };
 export default {
-  StatusBar,
+  StatusBar
 };

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -7,7 +7,8 @@
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */,
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    "types": ["node", "vscode"]
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
Hello, this MR adds support for Helm Chart dependencies (in `Chart.yaml` files).

<img width="438" height="216" alt="image" src="https://github.com/user-attachments/assets/ecc7d320-6ba4-42b9-b3ab-9c3c6cd337e2" />

<img width="426" height="447" alt="image" src="https://github.com/user-attachments/assets/8b1af62a-8cae-400b-b1e1-50dac12d2fbf" />

<img width="431" height="215" alt="image" src="https://github.com/user-attachments/assets/b6cbbeb0-6a8e-4057-ae4e-a91b2795c26a" />


It does not support `oci://` registries at the moment, as most of these require authentication (docker.io for example).