### PR TITLE
Fix exact version constraint handling in possibleLatestVersion function

### DIFF
--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependi",
-  "version": "0.7.15",
+  "version": "0.7.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dependi",
-      "version": "0.7.15",
+      "version": "0.7.17",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@neuralegion/cvss": "1.2.2",

--- a/vscode/src/core/parsers/PypiParser.ts
+++ b/vscode/src/core/parsers/PypiParser.ts
@@ -185,7 +185,7 @@ export function possibleLatestVersion(
         : null;
     }
     // Return with = prefix to indicate exact match (semver compatible)
-    return "=" + exactVersionConstraint.slice(2).trim();
+    return exactVersionConstraint.slice(2).trim();
   } else if (constraints.some((constraint) => constraint.includes("*"))) {
     let majorVersion = constraints
       .find((constraint) => constraint.trim().startsWith("=="))


### PR DESCRIPTION
Remove the '=' prefix from the exact version constraint in the possibleLatestVersion function to improve version compatibility. Update the version in the package.json file accordingly.