### PR TITLE
feat: add support for C# file-based app

### DIFF
--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -14,7 +14,8 @@
         "fast-xml-parser": "5.2.5",
         "node-cache": "5.1.2",
         "release-please": "16.12.0",
-        "semver": "7.6.3"
+        "semver": "7.6.3",
+        "semver-regex": "4.0.5"
       },
       "devDependencies": {
         "@types/glob": "8.1.0",
@@ -4266,6 +4267,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/semver-regex": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-javascript": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -85,6 +85,8 @@
     "workspaceContains:**/Directory.Build.props",
     "onLanguage:Directory.Packages.props",
     "workspaceContains:**/Directory.Packages.props",
+    "onLanguage:cs",
+    "workspaceContains:**/*.cs",
     "onLanguage:pubspec.yaml",
     "workspaceContains:**/pubspec.yaml"
   ],
@@ -1060,7 +1062,8 @@
     "fast-xml-parser": "5.2.5",
     "node-cache": "5.1.2",
     "release-please": "16.12.0",
-    "semver": "7.6.3"
+    "semver": "7.6.3",
+    "semver-regex": "4.0.5"
   },
   "extensionDependencies": [
     "vscode.git"

--- a/vscode/src/api/indexes/dependi/reports.ts
+++ b/vscode/src/api/indexes/dependi/reports.ts
@@ -58,7 +58,7 @@ export const getLangIdFromName = (name: string): Language => {
   if (exactMatch) {
     return exactMatch.ID;
   }
-  if (name.toLowerCase().endsWith(".csproj")) {
+  if (name.toLowerCase().endsWith(".csproj") || name.toLowerCase().endsWith(".cs")) {
     return Language.CSharp;
   }
   return Language.None;

--- a/vscode/src/commands/report-generator/utils.ts
+++ b/vscode/src/commands/report-generator/utils.ts
@@ -12,6 +12,7 @@ import { PyProjectParser } from "../../core/parsers/PyProjectParser";
 import { openDeviceLimitDialog, openPaymentRequiredDialog, openSettingsDialog } from "../../ui/dialogs";
 import { PubspecParser } from "../../core/parsers/PubspecParser";
 import { CsprojParser } from "../../core/parsers/CsprojParser";
+import { CsFileParser } from "../../core/parsers/CsFileParser";
 
 export const parserInvoker = (language: string) => {
   switch (language) {
@@ -33,7 +34,10 @@ export const parserInvoker = (language: string) => {
     case "Directory.Packages.props":
       return new CsprojParser();
     default:
-      // Check if it's a .csproj file
+      // Check either .cs or .csproj file
+      if (language.endsWith(".cs")) {
+        return new CsFileParser();
+      }
       if (language.endsWith(".csproj")) {
         return new CsprojParser();
       }

--- a/vscode/src/core/Language.ts
+++ b/vscode/src/core/Language.ts
@@ -53,7 +53,7 @@ export function setLanguage(file?: string) {
         case "directory.packages.props":
             return setLanguageConfig(Language.CSharp, "csharp", filename, OCVEnvironment.Nuget); 
         default:
-            if (fileExtension === ".csproj") {
+            if (fileExtension === ".csproj" || fileExtension === ".cs") {
                 return setLanguageConfig(Language.CSharp, "csharp", filename, OCVEnvironment.Nuget);
             }
             if ((fileExtension === ".txt" || fileExtension === ".in") && filename.toLowerCase().startsWith("requirement")) {

--- a/vscode/src/core/listeners/index.ts
+++ b/vscode/src/core/listeners/index.ts
@@ -27,7 +27,7 @@ import { PubspecListener } from "./PubspecListener";
 import { PubDevFetcher } from "../fetchers/PubDevFetcher";
 import { PubspecParser } from "../parsers/PubspecParser";
 import { NuGetFetcher } from "../fetchers/NuGetFetcher";
-import { CsprojParser } from "../parsers/CsprojParser";
+import { CsParser } from "../parsers/CsParser";
 import { CSharpListener } from "./CSharpListener";
 
 export default async function listener(editor: TextEditor | undefined): Promise<void> {
@@ -90,7 +90,7 @@ export default async function listener(editor: TextEditor | undefined): Promise<
         return;
       listener = new CSharpListener(
         new NuGetFetcher(Settings.csharp.index, Configs.CSHARP_INDEX_SERVER_URL),
-        new CsprojParser());
+        new CsParser());
       break;
   }
   if (listener !== undefined) {

--- a/vscode/src/core/parsers/CsFileParser.ts
+++ b/vscode/src/core/parsers/CsFileParser.ts
@@ -1,0 +1,55 @@
+import { TextDocument } from "vscode";
+import Item from "../Item";
+import { Parser } from "./parser";
+import semverRegex from 'semver-regex';
+
+export class CsFileParser implements Parser {
+  parse(doc: TextDocument): Item[] {
+    let items: Item[] = [];
+    
+    for (let row = 0; row < doc.lineCount; row++) {
+      const line = doc.lineAt(row);
+    
+      if (line.isEmptyOrWhitespace) {
+        continue;
+      }
+
+      const isShebang = line.text.startsWith("#!");
+      if (isShebang) {
+        continue;
+      }
+
+      const matches = /^#:package (.+)@(.+)/.exec(line.text);
+      if (matches) {
+        const packageName = matches[1];
+        const packagePart = matches[2].trim();
+
+        const packageVersion = packagePart.match(semverRegex())?.[0];
+        if (!packageVersion) {
+          continue;
+        }
+
+        const endOfPackageName = "#:package".length + packageName.length;
+        const startOfVersion = line.text.indexOf(packageVersion, endOfPackageName);
+        const endOfVersion = startOfVersion + packageVersion.length;
+
+        const item = new Item();
+        item.copyFrom(
+          packageName,
+          packageVersion,
+          startOfVersion,
+          endOfVersion,
+          line.lineNumber,
+          line.range.end.character
+        );
+        item.createRange();
+        item.createDecoRange();
+        items.push(item);
+      }
+
+      break;
+    }
+
+    return items;
+  }
+}

--- a/vscode/src/core/parsers/CsParser.ts
+++ b/vscode/src/core/parsers/CsParser.ts
@@ -1,0 +1,17 @@
+import { TextDocument } from "vscode";
+import Item from "../Item";
+import { Parser } from "./parser";
+import { CsprojParser } from "./CsprojParser";
+import { CsFileParser } from "./CsFileParser";
+
+export class CsParser implements Parser {
+  csprojParser = new CsprojParser();
+  csFileParser = new CsFileParser();
+
+  parse(doc: TextDocument): Item[] {
+    if (doc.fileName.endsWith(".cs")) {
+      return this.csFileParser.parse(doc);
+    }
+    return this.csprojParser.parse(doc);
+  }
+}


### PR DESCRIPTION
Support the new C# file-based app. This new type of project consist of a single `*.cs` file that self contain the package reference/version.

You can find an example of how this file looks: https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/tutorials/file-based-programs#test-the-final-application 