### PR TITLE
Add support for pnpm workspace protocol and catalogs in YAML parser

### DIFF
--- a/vscode/changelog.md
+++ b/vscode/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "dependi" extension will be documented in this file.
 
+## [v0.7.19](https://github.com/filllabs/dependi/compare/v0.7.18...v0.7.19)
+
+### New Features
+
+- Support for pnpm `workspace:` protocol and `catalog:` from `pnpm-workspace.yaml`. ([Issue #200](https://github.com/filllabs/dependi/issues/200))
+
 ## [v0.7.18](https://github.com/filllabs/dependi/compare/v0.7.17...v0.7.18)
 
 ### New Features

--- a/vscode/src/core/Language.ts
+++ b/vscode/src/core/Language.ts
@@ -12,6 +12,7 @@ export enum Language {
     PHP = 5,
     Dart = 6,
     CSharp = 7,
+    PnpmWorkspace = 8,
 }
 
 export enum OCVEnvironment {
@@ -41,6 +42,8 @@ export function setLanguage(file?: string) {
             return setLanguageConfig(Language.Golang, "go", filename, OCVEnvironment.Go);
         case "package.json":
             return setLanguageConfig(Language.JS, "npm", filename, OCVEnvironment.Npm, Settings.npm.lockFileEnabled);
+        case "pnpm-workspace.yaml":
+            return setLanguageConfig(Language.PnpmWorkspace, "npm", filename, OCVEnvironment.Npm);
         case "composer.json":
             return setLanguageConfig(Language.PHP, "php", filename, OCVEnvironment.Packagist, Settings.php.lockFileEnabled);
         case "pyproject.toml":

--- a/vscode/src/core/listeners/PnpmWorkspaceListener.ts
+++ b/vscode/src/core/listeners/PnpmWorkspaceListener.ts
@@ -1,0 +1,9 @@
+import { Fetcher } from "../fetchers/fetcher";
+import { Parser } from "../parsers/parser";
+import { Listener } from "./listener";
+
+export class PnpmWorkspaceListener extends Listener {
+  constructor(fetcher: Fetcher, parser: Parser) {
+    super(fetcher, parser);
+  }
+}

--- a/vscode/src/core/listeners/index.ts
+++ b/vscode/src/core/listeners/index.ts
@@ -16,11 +16,13 @@ import { NpmParser } from "../parsers/PackageJsonParser";
 import { PhpParser } from "../parsers/ComposerJsonParser";
 import { PyProjectParser } from "../parsers/PyProjectParser";
 import { PypiParser } from "../parsers/PypiParser";
+import { PnpmWorkspaceYamlParser } from "../parsers/PnpmWorkspaceYamlParser";
 import { CargoTomlListener } from "./CargoTomlListener";
 import { DependiListener } from "./DependiListener";
 import { GoModListener } from "./GoModListener";
 import { NpmListener } from "./NpmListener";
 import { PhpListener } from './PhpListener';
+import { PnpmWorkspaceListener } from "./PnpmWorkspaceListener";
 import { PypiListener } from "./PypiListener";
 import { Listener } from "./listener";
 import { PubspecListener } from "./PubspecListener";
@@ -58,6 +60,13 @@ export default async function listener(editor: TextEditor | undefined): Promise<
       listener = new NpmListener(
         new NpmFetcher(Settings.npm.index, Configs.NPM_INDEX_SERVER_URL),
         new NpmParser());
+      break;
+    case Language.PnpmWorkspace:
+      if (!Settings.npm.enabled)
+        return;
+      listener = new PnpmWorkspaceListener(
+        new NpmFetcher(Settings.npm.index, Configs.NPM_INDEX_SERVER_URL),
+        new PnpmWorkspaceYamlParser());
       break;
     case Language.PHP:
       if (!Settings.php.enabled)

--- a/vscode/src/core/parsers/PackageJsonParser.ts
+++ b/vscode/src/core/parsers/PackageJsonParser.ts
@@ -1,16 +1,14 @@
 import { Settings } from "../../config";
-import * as vscode from "vscode";
 import Item from "../Item";
 import { JsonParser } from "./JsonParser";
 import { PackageLockJsonParser } from "./PackageLockJsonParser";
-import path, { dirname } from "path";
-import * as fs from "fs";
-import { clearText } from "./TomlParser";
 
 export class NpmParser extends JsonParser {
   constructor() {
     super(
       [
+        "catalog",
+        "catalogs",
         "dependencies",
         "devDependencies",
         "peerDependencies",
@@ -22,62 +20,17 @@ export class NpmParser extends JsonParser {
     );
   }
 
+  
+
   addDependency(item: Item) {
-    if (item.value?.startsWith("link:")) {
+    const skipPrefixes = ["link:", "catalog:", "workspace:"];
+    if (skipPrefixes.some(prefix => item.value?.startsWith(prefix))) {
       return;
     }
     item = convertAliasToPackageName(item);
     item.createRange();
     item.createDecoRange();
-    if (item.value?.startsWith("catalog:")) {
-      this.loadYamlLinesIfNeeded();
-
-      if (this.state.yamlLines.length > 0) {
-        this.updateItemValueFromCatalog(item);
-      }
-    }
     this.state.items.push(item);
-  }
-  private loadYamlLinesIfNeeded() {
-    if (this.state.yamlLines.length === 0) {
-      const filePath = vscode.window.activeTextEditor?.document.uri.fsPath;
-      const workspaceFolder = vscode.workspace.getWorkspaceFolder(
-        vscode.Uri.file(filePath || "")
-      );
-      const rootPath = workspaceFolder?.uri.fsPath as string;
-
-      try {
-        const files = fs.readdirSync(rootPath);
-        const yamlFile = files.find((file) => file === "pnpm-workspace.yaml");
-        if (yamlFile) {
-          const yamlFilePath = path.join(rootPath, yamlFile);
-          const yamlContent = fs.readFileSync(yamlFilePath, "utf8");
-          this.state.yamlLines = yamlContent.split("\n");
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    }
-  }
-
-  private updateItemValueFromCatalog(item: Item) {
-    let catalogName = item.value?.replace("catalog:", "");
-    if (catalogName?.trim() === "") {
-      catalogName = item.key;
-    }
-
-    const catalogLine = this.state.yamlLines.find((line) => {
-      const catalogKey = line
-        .split(":")[0]
-        .trim()
-        .replace(/^['"]|['"]$/g, "");
-      return catalogKey === item.key || catalogKey === catalogName;
-    });
-
-    if (catalogLine) {
-      const catalogValue = clearText(catalogLine.split(":")[1].trim());
-      item.value = catalogValue;
-    }
   }
 }
 

--- a/vscode/src/core/parsers/PnpmWorkspaceYamlParser.ts
+++ b/vscode/src/core/parsers/PnpmWorkspaceYamlParser.ts
@@ -1,0 +1,137 @@
+import { TextDocument, TextLine } from "vscode";
+import Item from "../Item";
+import { Parser } from "./parser";
+import { shouldIgnoreLine } from "./utils";
+
+class State {
+  inCatalogs: boolean;
+  inCatalogBlock: boolean;
+  currentCatalogName: string;
+  items: Item[];
+  catalogDepth: number;
+  isSingleCatalog: boolean; // Track if using "catalog:" (single) vs "catalogs:" (multiple)
+  
+  constructor() {
+    this.inCatalogs = false;
+    this.inCatalogBlock = false;
+    this.currentCatalogName = "";
+    this.items = [] as Item[];
+    this.catalogDepth = 0;
+    this.isSingleCatalog = false;
+  }
+}
+
+export class PnpmWorkspaceYamlParser implements Parser {
+  parse(doc: TextDocument): Item[] {
+    const state = new State();
+    
+    for (let row = 0; row < doc.lineCount; row++) {
+      const line = doc.lineAt(row);
+      
+      if (shouldIgnoreLine(line, "", ["#"])) {
+        continue;
+      }
+      
+      // Check if we're entering catalogs section
+      if (isCatalogsStart(line)) {
+        state.inCatalogs = true;
+        state.catalogDepth = 0;
+        state.isSingleCatalog = line.text.trim() === "catalog:";
+        // If single catalog, we can parse dependencies immediately
+        if (state.isSingleCatalog) {
+          state.inCatalogBlock = true;
+        }
+        continue;
+      }
+      
+      if (state.inCatalogs) {
+        const indentLevel = getIndentLevel(line);
+        
+        // If we're back to root level (no indent), we've exited catalogs
+        if (indentLevel === 0 && line.text.trim() !== "") {
+          state.inCatalogs = false;
+          state.inCatalogBlock = false;
+          continue;
+        }
+        
+        // For multiple catalogs, check if this is a catalog name (e.g., "default:", "react18:")
+        if (!state.isSingleCatalog && isCatalogName(line)) {
+          state.inCatalogBlock = true;
+          state.currentCatalogName = getCatalogName(line);
+          continue;
+        }
+        
+        // If we're in a catalog block, parse dependencies
+        if (state.inCatalogBlock) {
+          const item = parseDependencyLine(line);
+          if (item && item.key && item.value) {
+            state.items.push(item);
+          }
+        }
+      }
+    }
+    
+    return state.items;
+  }
+}
+
+function isCatalogsStart(line: TextLine): boolean {
+  const text = line.text.trim();
+  return text === "catalogs:" || text === "catalog:";
+}
+
+function isCatalogName(line: TextLine): boolean {
+  // Catalog names are indented once and end with ":"
+  const indentLevel = getIndentLevel(line);
+  const text = line.text.trim();
+  return indentLevel === 2 && text.endsWith(":") && !text.includes(" ");
+}
+
+function getCatalogName(line: TextLine): string {
+  const text = line.text.trim();
+  return text.slice(0, -1); // Remove the trailing ":"
+}
+
+function getIndentLevel(line: TextLine): number {
+  return line.firstNonWhitespaceCharacterIndex;
+}
+
+function parseDependencyLine(line: TextLine): Item | null {
+  const text = line.text.trim();
+  
+  // Skip empty lines and lines without ":"
+  if (!text || !text.includes(":")) {
+    return null;
+  }
+  
+  const colonIndex = text.indexOf(":");
+  const key = text.substring(0, colonIndex).trim().replace(/['"]/g, "");
+  let value = text.substring(colonIndex + 1).trim().replace(/['"]/g, "");
+  
+  // Remove trailing comments
+  if (value.includes("#")) {
+    value = value.substring(0, value.indexOf("#")).trim();
+  }
+  
+  if (!key || !value) {
+    return null;
+  }
+  
+  // Calculate positions in the original line
+  const startOfValue = line.text.indexOf(value);
+  const endOfValue = startOfValue + value.length;
+  
+  const item = new Item();
+  item.copyFrom(
+    key,
+    value,
+    startOfValue,
+    endOfValue,
+    line.lineNumber,
+    line.range.end.character
+  );
+  item.createRange();
+  item.createDecoRange();
+  
+  return item;
+}


### PR DESCRIPTION
Introduce support for the pnpm `workspace:` protocol and `catalog:` entries in the `pnpm-workspace.yaml` file. This enhancement allows for better handling of dependencies and catalogs within the parser. The implementation includes a new listener and parser specifically for pnpm workspace files.