### PR TITLE
feat: Add Terraform module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Dependi: Your Ultimate Dependency Management Tool
 
-Dependi is a comprehensive dependency management extension that helps developers write code faster and smarter by efficiently managing project dependencies. Formerly known as Crates the most loved and used dependency management extension for Rust. Dependi now supports multiple languages including Rust, Go, JavaScript, TypeScript, Python, PHP, Dart and C#.
+Dependi is a comprehensive dependency management extension that helps developers write code faster and smarter by efficiently managing project dependencies. Formerly known as Crates the most loved and used dependency management extension for Rust. Dependi now supports multiple languages including Rust, Go, JavaScript, TypeScript, Python, PHP, Dart, C#, Elixir, Gradle (Java/Kotlin), and Terraform.
 
 [Install](https://www.dependi.io/download) Dependi via VSCode or [Dependi.io](https://www.dependi.io)
 
 
 When you install Dependi in Visual Studio Code, 2 options are available :
 
-- Dependi Core: Provides essential dependency management for Rust, Go, JavaScript, TypeScript, Python, PHP, Dart and C# projects. Free to use with no subscription required.
+- Dependi Core: Provides essential dependency management for Rust, Go, JavaScript, TypeScript, Python, PHP, Dart, C#, Elixir, Gradle (Java/Kotlin), and Terraform projects. Free to use with no subscription required.
 
 - [Dependi Pro:](https://www.dependi.io) Offers many advanced features like detailed vulnerability reports, private repository support, and priority support... Easy subscription packages and [free trials](https://www.dependi.io/#pricing) are available.
 
@@ -41,6 +41,15 @@ Dependi simplifies dependency management in Visual Studio Code, helping you to:
   - **C#**
     - Documentation: [https://dot.net/docs](https://dot.net/docs)
     - Package Repository (NuGet): [https://www.nuget.org/](https://www.nuget.org/)
+  - **Elixir**:
+    - Documentation: [https://elixir-lang.org/docs.html](https://elixir-lang.org/docs.html)
+    - Package Repository (Hex): [https://hex.pm](https://hex.pm)
+  - **Gradle (Java / Kotlin)**:
+    - Documentation: [https://docs.gradle.org](https://docs.gradle.org)
+    - Package Repository (Maven Central): [https://repo1.maven.org/maven2](https://repo1.maven.org/maven2)
+  - **Terraform**:
+    - Documentation: [https://developer.hashicorp.com/terraform/docs](https://developer.hashicorp.com/terraform/docs)
+    - Module Registry: [https://registry.terraform.io](https://registry.terraform.io)
     
 - **Vulnerabilities at a Glance**: Quickly identify vulnerabilities in your project dependencies and take action to mitigate risks.
   ![Vulnerabilities at a Glance](https://www.dependi.io/screenshots/vuln.png)
@@ -48,7 +57,7 @@ Dependi simplifies dependency management in Visual Studio Code, helping you to:
 - **Vulnerability Reports**: Generate comprehensive reports detailing the vulnerabilities in your dependencies, helping you maintain secure codebases.
   ![Vulnerability Reports](https://www.dependi.io/screenshots/report.png)
 
-- **Supported Languages and Frameworks**: Dependi works with a variety of languages including Rust, Go, JavaScript, TypeScript, Python, PHP, Dart and C#. It is designed to support most popular languages and frameworks, making it a versatile tool for developers.
+- **Supported Languages and Frameworks**: Dependi works with a variety of languages including Rust, Go, JavaScript, TypeScript, Python, PHP, Dart, C#, Elixir, Gradle (Java/Kotlin), and Terraform. It is designed to support most popular languages and frameworks, making it a versatile tool for developers.
 
 For more information about the feature set [visit here](https://www.dependi.io/#features).
 

--- a/vscode/changelog.md
+++ b/vscode/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "dependi" extension will be documented in this file.
 
+## [v0.7.27](https://github.com/filllabs/dependi/compare/v0.7.26...v0.7.27)
+
+### New Features
+
+- Added support for Terraform module version management in `.tf` files, including Terraform Registry lookups for modules in `namespace/name/provider` format. ([Issue #235](https://github.com/filllabs/dependi/issues/235))
+
 ## [v0.7.26](https://github.com/filllabs/dependi/compare/v0.7.25...v0.7.26)
 
 ### New Features

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependi",
-  "version": "0.7.26",
+  "version": "0.7.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dependi",
-      "version": "0.7.26",
+      "version": "0.7.27",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@neuralegion/cvss": "1.2.2",

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependi",
-  "version": "0.7.21",
+  "version": "0.7.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dependi",
-      "version": "0.7.21",
+      "version": "0.7.26",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@neuralegion/cvss": "1.2.2",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -837,7 +837,12 @@
             "default": false,
             "description": "Consider non-registry packages as up-to-date if their version exceeds the max.",
             "order": 68
-          },
+          }
+        }
+      },
+      {
+        "title": "Terraform Settings",
+        "properties": {
           "dependi.terraform.enabled": {
             "type": "boolean",
             "scope": "resource",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dependi",
   "displayName": "Dependi",
-  "description": "Empowers developers to efficiently manage dependencies and address vulnerabilities in Rust, Go, JavaScript, Typescript, PHP, Python, Dart, C#, F#, Elixir, and Gradle (Java/Kotlin) projects.",
+  "description": "Empowers developers to efficiently manage dependencies and address vulnerabilities in Rust, Go, JavaScript, Typescript, PHP, Python, Dart, C#, F#, Elixir, Gradle (Java/Kotlin), and Terraform projects.",
   "version": "0.7.26",
   "publisher": "fill-labs",
   "author": {
@@ -58,6 +58,10 @@
     "kotlin",
     "maven",
     "android",
+    "terraform",
+    "hcl",
+    "infrastructure",
+    "iac",
     "package",
     "dependi",
     "requirements",
@@ -110,7 +114,9 @@
     "workspaceContains:**/build.gradle",
     "workspaceContains:**/build.gradle.kts",
     "workspaceContains:**/libs.versions.toml",
-    "workspaceContains:**/gradle-wrapper.properties"
+    "workspaceContains:**/gradle-wrapper.properties",
+    "onLanguage:terraform",
+    "workspaceContains:**/*.tf"
   ],
   "contributes": {
     "menus": {
@@ -831,6 +837,60 @@
             "default": false,
             "description": "Consider non-registry packages as up-to-date if their version exceeds the max.",
             "order": 68
+          },
+          "dependi.terraform.enabled": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": true,
+            "description": "Enable checking for Terraform module versions in .tf files.",
+            "order": 69
+          },
+          "dependi.terraform.indexServerURL": {
+            "type": "string",
+            "scope": "resource",
+            "description": "The URL for the Terraform Registry API server.",
+            "format": "url",
+            "pattern": "^https?://(?!.*//)([^/]+/)*[^/]+$",
+            "default": "https://registry.terraform.io",
+            "order": 70
+          },
+          "dependi.terraform.unstableFilter": {
+            "type": "string",
+            "enum": [
+              "Exclude",
+              "IncludeAlways",
+              "IncludeIfUnstable"
+            ],
+            "default": "Exclude",
+            "scope": "resource",
+            "enumDescriptions": [
+              "Exclude them (default)",
+              "Include them and always consider as latest",
+              "Include if the current version is already unstable"
+            ],
+            "description": "Filter unstable versions: Exclude, Include Always, or Include If Unstable.",
+            "order": 71
+          },
+          "dependi.terraform.ignoreLinePatterns": {
+            "type": "string",
+            "scope": "resource",
+            "default": "",
+            "markdownDescription": "Matches lines based on `*` position: `text*`, `*text`, `*text*`. Multiple patterns can be used, separated by commas.",
+            "order": 72
+          },
+          "dependi.terraform.informPatchUpdates": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": false,
+            "description": "Inform about available patch updates for Terraform modules via decoration.",
+            "order": 73
+          },
+          "dependi.terraform.silenceVersionOverflows": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": false,
+            "description": "Consider non-registry modules as up-to-date if their version exceeds the max.",
+            "order": 74
           }
         }
       },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "dependi",
   "displayName": "Dependi",
   "description": "Empowers developers to efficiently manage dependencies and address vulnerabilities in Rust, Go, JavaScript, Typescript, PHP, Python, Dart, C#, F#, Elixir, Gradle (Java/Kotlin), and Terraform projects.",
-  "version": "0.7.26",
+  "version": "0.7.27",
   "publisher": "fill-labs",
   "author": {
     "name": "Fill Labs",

--- a/vscode/src/api/indexes/dependi/reports.ts
+++ b/vscode/src/api/indexes/dependi/reports.ts
@@ -43,6 +43,7 @@ export enum Language {
   PnpmWorkspace,
   Elixir,
   Gradle,
+  Terraform,
 }
 
 const LanguageArray = [
@@ -59,6 +60,7 @@ const LanguageArray = [
   { ID: Language.Gradle, Name: "build.gradle.kts" },
   { ID: Language.Gradle, Name: "libs.versions.toml" },
   { ID: Language.Gradle, Name: "gradle-wrapper.properties" },
+  { ID: Language.Terraform, Name: "main.tf" },
 ];
 
 export const getLangIdFromName = (name: string): Language => {
@@ -68,6 +70,9 @@ export const getLangIdFromName = (name: string): Language => {
   }
   if (name.toLowerCase().endsWith(".csproj") || name.toLowerCase().endsWith(".fsproj")) {
     return Language.CSharp;
+  }
+  if (name.toLowerCase().endsWith(".tf")) {
+    return Language.Terraform;
   }
   return Language.None;
 };

--- a/vscode/src/api/indexes/terraform.ts
+++ b/vscode/src/api/indexes/terraform.ts
@@ -7,10 +7,11 @@ import { makeRequest } from './request';
 
 export const versions = (name: string) => {
   return new Promise<DependencyInfo>(function (resolve, reject) {
-    // name format: "namespace/name/provider" or "terraform-aws-modules/vpc/aws"
+    // name format: "namespace/name/provider" (e.g. terraform-aws-modules/vpc/aws)
     const parts = name.split('/');
-    if (parts.length !== 3) {
-      return reject(new Error(`Invalid Terraform module name format: ${name}. Expected format: namespace/name/provider`));
+    if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+      // Non-registry sources (local paths, git, etc.) are skipped by the parser.
+      return resolve({ name, versions: [] });
     }
 
     const [namespace, moduleName, provider] = parts;
@@ -27,16 +28,15 @@ export const versions = (name: string) => {
         try {
           const bodyString = Buffer.concat(body).toString();
           const json = JSON.parse(bodyString);
-          
+
           if (!json.modules || !json.modules[0] || !json.modules[0].versions) {
             return reject(
               new Error(`Invalid response from Terraform Registry: no versions found for ${name}`)
             );
           }
 
-          // Extract version strings from the response
-          const versionList = json.modules[0].versions.map((v: any) => v.version);
-          
+          const versionList = json.modules[0].versions.map((v: { version: string }) => v.version);
+
           info = {
             name: name,
             versions: versionList,

--- a/vscode/src/api/indexes/terraform.ts
+++ b/vscode/src/api/indexes/terraform.ts
@@ -1,0 +1,60 @@
+import { Settings } from "../../config";
+import { DependencyInfo } from '../DepencencyInfo';
+import { getReqOptions } from "../utils";
+import { addResponseHandlers, cleanURL, isStatusInvalid, ResponseError } from "./utils";
+import { ClientRequest, IncomingMessage } from 'http';
+import { makeRequest } from './request';
+
+export const versions = (name: string) => {
+  return new Promise<DependencyInfo>(function (resolve, reject) {
+    // name format: "namespace/name/provider" or "terraform-aws-modules/vpc/aws"
+    const parts = name.split('/');
+    if (parts.length !== 3) {
+      return reject(new Error(`Invalid Terraform module name format: ${name}. Expected format: namespace/name/provider`));
+    }
+
+    const [namespace, moduleName, provider] = parts;
+    const url = getURL(namespace, moduleName, provider);
+    const options = getReqOptions(url);
+
+    const handleResponse = (res: IncomingMessage, req: ClientRequest) => {
+      if (isStatusInvalid(res)) {
+        return reject(ResponseError(res));
+      }
+      const body = addResponseHandlers(name, res, req, reject);
+      let info: DependencyInfo;
+      res.on("end", () => {
+        try {
+          const bodyString = Buffer.concat(body).toString();
+          const json = JSON.parse(bodyString);
+          
+          if (!json.modules || !json.modules[0] || !json.modules[0].versions) {
+            return reject(
+              new Error(`Invalid response from Terraform Registry: no versions found for ${name}`)
+            );
+          }
+
+          // Extract version strings from the response
+          const versionList = json.modules[0].versions.map((v: any) => v.version);
+          
+          info = {
+            name: name,
+            versions: versionList,
+          };
+        } catch (e) {
+          reject(e);
+        }
+        resolve(info);
+      });
+    };
+
+    makeRequest(options, handleResponse, reject);
+  });
+};
+
+function getURL(namespace: string, name: string, provider: string) {
+  // Terraform Registry API v1 endpoint
+  const baseUrl = Settings.terraform.index || "https://registry.terraform.io";
+  const url = `${baseUrl}/v1/modules/${namespace}/${name}/${provider}/versions`;
+  return cleanURL(url);
+}

--- a/vscode/src/config.ts
+++ b/vscode/src/config.ts
@@ -83,6 +83,13 @@ export enum Configs {
   GRADLE_INFORM_PATCH_UPDATES = `gradle.informPatchUpdates`,
   GRADLE_SILENCE_VERSION_OVERFLOWS = `gradle.silenceVersionOverflows`,
 
+  TERRAFORM_ENABLED = `terraform.enabled`,
+  TERRAFORM_INDEX_SERVER_URL = `terraform.indexServerURL`,
+  TERRAFORM_UNSTABLE_FILTER = `terraform.unstableFilter`,
+  TERRAFORM_IGNORE_LINE_PATTERN = `terraform.ignoreLinePattern`,
+  TERRAFORM_INFORM_PATCH_UPDATES = `terraform.informPatchUpdates`,
+  TERRAFORM_SILENCE_VERSION_OVERFLOWS = `terraform.silenceVersionOverflows`,
+
   VULS_ENABLED = `vulnerability.enabled`,
   VULS_GHSA_ENABLED = `vulnerability.ghsa.enabled`,
   VULS_OSV_BATCH_URL = `vulnerability.osvQueryURL.batch`,
@@ -214,6 +221,14 @@ export const Settings = {
     informPatchUpdates: false,
     silenceVersionOverflows: false
   },
+  terraform: {
+    enabled: true,
+    index: "",
+    unstableFilter: UnstableFilter.Exclude,
+    ignoreLinePattern: "",
+    informPatchUpdates: false,
+    silenceVersionOverflows: false
+  },
   vulnerability: {
     enabled: false,
     ghsa: false,
@@ -328,6 +343,13 @@ export const Settings = {
     this.gradle.ignoreLinePattern = config.get<string>(Configs.GRADLE_IGNORE_LINE_PATTERN) || "";
     this.gradle.informPatchUpdates = config.get<boolean>(Configs.GRADLE_INFORM_PATCH_UPDATES) ?? false;
     this.gradle.silenceVersionOverflows = config.get<boolean>(Configs.GRADLE_SILENCE_VERSION_OVERFLOWS) ?? false;
+
+    this.terraform.enabled = config.get<boolean>(Configs.TERRAFORM_ENABLED) ?? true;
+    this.terraform.index = config.get<string>(Configs.TERRAFORM_INDEX_SERVER_URL) || "https://registry.terraform.io";
+    this.terraform.unstableFilter = UnstableFilter[config.get<string>(Configs.TERRAFORM_UNSTABLE_FILTER) as keyof typeof UnstableFilter] || UnstableFilter.Exclude;
+    this.terraform.ignoreLinePattern = config.get<string>(Configs.TERRAFORM_IGNORE_LINE_PATTERN) || "";
+    this.terraform.informPatchUpdates = config.get<boolean>(Configs.TERRAFORM_INFORM_PATCH_UPDATES) ?? false;
+    this.terraform.silenceVersionOverflows = config.get<boolean>(Configs.TERRAFORM_SILENCE_VERSION_OVERFLOWS) ?? false;
 
     this.vulnerability.enabled = config.get<boolean>(Configs.VULS_ENABLED) ?? true;
     this.vulnerability.ghsa = config.get<boolean>(Configs.VULS_GHSA_ENABLED) ?? false;

--- a/vscode/src/core/Language.ts
+++ b/vscode/src/core/Language.ts
@@ -15,6 +15,7 @@ export enum Language {
     PnpmWorkspace = 8,
     Elixir = 9,
     Gradle = 10,
+    Terraform = 11,
 }
 
 export enum OCVEnvironment {
@@ -27,6 +28,7 @@ export enum OCVEnvironment {
     Nuget = "NuGet",
     Hex = "Hex",
     Maven = "Maven",
+    Terraform = "Terraform",
 }
 export var CurrentLanguage: Language = Language.None;
 export var CurrentLanguageConfig: string = "";
@@ -68,8 +70,11 @@ export function setLanguage(file?: string) {
             return setLanguageConfig(Language.Gradle, "gradle", filename, OCVEnvironment.Maven);
         case "directory.build.props":
         case "directory.packages.props":
-            return setLanguageConfig(Language.CSharp, "csharp", filename, OCVEnvironment.Nuget); 
+            return setLanguageConfig(Language.CSharp, "csharp", filename, OCVEnvironment.Nuget);
         default:
+            if (fileExtension === ".tf") {
+                return setLanguageConfig(Language.Terraform, "terraform", filename, OCVEnvironment.Terraform);
+            }
             if (fileExtension === ".csproj" || fileExtension === ".fsproj") {
                 return setLanguageConfig(Language.CSharp, "csharp", filename, OCVEnvironment.Nuget);
             }

--- a/vscode/src/core/fetchers/TerraformFetcher.ts
+++ b/vscode/src/core/fetchers/TerraformFetcher.ts
@@ -1,0 +1,22 @@
+import { versions } from "../../api/indexes/terraform";
+import { Settings } from "../../config";
+import compareVersions from "../../semver/compareVersions";
+import { fetcherCatch } from "../../utils/errors";
+import Dependency from "../Dependency";
+import { Fetcher } from "./fetcher";
+
+export class TerraformFetcher extends Fetcher {
+
+  fetch(): (i: Dependency) => Promise<Dependency> {
+    const base = this;
+    return async function (dep: Dependency): Promise<Dependency> {
+      return versions(dep.item.key).then((mod) => {
+        const versionList = mod.versions
+          .filter((i: string) => i !== "" && i !== undefined && !base.checkUnstables(Settings.terraform.unstableFilter, i, dep.item.value!))
+          .sort(compareVersions).reverse();
+        dep.versions = versionList;
+        return dep;
+      }).catch(fetcherCatch(dep));
+    };
+  };
+}

--- a/vscode/src/core/listeners/TerraformListener.ts
+++ b/vscode/src/core/listeners/TerraformListener.ts
@@ -1,0 +1,5 @@
+import { Listener } from "./listener";
+
+export class TerraformListener extends Listener {
+  // Terraform listener uses the base Listener implementation
+}

--- a/vscode/src/core/listeners/index.ts
+++ b/vscode/src/core/listeners/index.ts
@@ -38,6 +38,9 @@ import { MixExsParser } from "../parsers/MixExsParser";
 import { GradleListener } from "./GradleListener";
 import { MavenFetcher } from "../fetchers/MavenFetcher";
 import { GradleParser } from "../parsers/GradleParser";
+import { TerraformListener } from "./TerraformListener";
+import { TerraformFetcher } from "../fetchers/TerraformFetcher";
+import { TerraformParser } from "../parsers/TerraformParser";
 
 let listenerTimer: NodeJS.Timeout | undefined;
 let isListening = false;
@@ -161,6 +164,13 @@ async function runListener(editor: TextEditor | undefined): Promise<void> {
       listener = new GradleListener(
         new MavenFetcher(Settings.gradle.index, Configs.GRADLE_INDEX_SERVER_URL),
         new GradleParser());
+      break;
+    case Language.Terraform:
+      if (!Settings.terraform.enabled)
+        return;
+      listener = new TerraformListener(
+        new TerraformFetcher(Settings.terraform.index, Configs.TERRAFORM_INDEX_SERVER_URL),
+        new TerraformParser());
       break;
   }
   if (listener !== undefined) {

--- a/vscode/src/core/parsers/TerraformParser.ts
+++ b/vscode/src/core/parsers/TerraformParser.ts
@@ -101,8 +101,11 @@ export class TerraformParser {
 
           // Exit module block when all braces are closed
           if (state.braceDepth <= 0) {
-            this.resetModuleState(state, false, 0);
             state.inModule = false;
+            state.inModuleBlock = false;
+            state.moduleSource = "";
+            state.pendingVersionLine = null;
+            state.braceDepth = 0;
           }
         }
       }

--- a/vscode/src/core/parsers/TerraformParser.ts
+++ b/vscode/src/core/parsers/TerraformParser.ts
@@ -1,0 +1,125 @@
+import { TextDocument, TextLine } from "vscode";
+import Item from "../Item";
+import { isQuote, shouldIgnoreLine } from "./utils";
+import { Settings } from "../../config";
+
+class State {
+  inModule: boolean;
+  inModuleBlock: boolean;
+  currentModule: string;
+  items: Item[];
+  braceDepth: number;
+
+  constructor() {
+    this.inModule = false;
+    this.inModuleBlock = false;
+    this.currentModule = "";
+    this.items = [] as Item[];
+    this.braceDepth = 0;
+  }
+}
+
+export class TerraformParser {
+  parse(doc: TextDocument): Item[] {
+    let state = new State();
+
+    for (let row = 0; row < doc.lineCount; row++) {
+      let line = doc.lineAt(row);
+      if (shouldIgnoreLine(line, Settings.terraform.ignoreLinePattern, ["#", "//"])) {
+        continue;
+      }
+
+      const text = line.text.trim();
+
+      // Check for module block start
+      const moduleMatch = text.match(/^module\s+"([^"]+)"\s*\{/);
+      if (moduleMatch) {
+        state.inModule = true;
+        state.inModuleBlock = true;
+        state.currentModule = moduleMatch[1];
+        state.braceDepth = 1;
+        continue;
+      }
+
+      // Handle module block that starts without opening brace on same line
+      const moduleMatchNoBrace = text.match(/^module\s+"([^"]+)"\s*$/);
+      if (moduleMatchNoBrace) {
+        state.inModule = true;
+        state.currentModule = moduleMatchNoBrace[1];
+        continue;
+      }
+
+      // Track braces when in module
+      if (state.inModule) {
+        // Check for opening brace if we haven't entered the block yet
+        if (!state.inModuleBlock && text.includes("{")) {
+          state.inModuleBlock = true;
+          state.braceDepth = 1;
+        }
+
+        if (state.inModuleBlock) {
+          // Count braces to track nesting
+          state.braceDepth += (text.match(/{/g) || []).length;
+          state.braceDepth -= (text.match(/}/g) || []).length;
+
+          // Parse source and version lines
+          if (text.includes("source")) {
+            // source = "namespace/name/provider" or source = "..."
+            const sourceMatch = text.match(/source\s*=\s*"([^"]+)"/);
+            if (sourceMatch) {
+              state.currentModule = sourceMatch[1];
+            }
+          }
+
+          if (text.includes("version")) {
+            // version = "1.0.0" or version = ">= 1.0.0"
+            const item = this.parseVersionLine(line, state.currentModule);
+            if (item) {
+              state.items.push(item);
+            }
+          }
+
+          // Exit module block when all braces are closed
+          if (state.braceDepth <= 0) {
+            state.inModule = false;
+            state.inModuleBlock = false;
+            state.currentModule = "";
+          }
+        }
+      }
+    }
+
+    return state.items;
+  }
+
+  private parseVersionLine(line: TextLine, moduleName: string): Item | null {
+    const text = line.text;
+    const start = line.firstNonWhitespaceCharacterIndex;
+
+    // Match: version = "1.0.0" or version = ">= 1.0.0"
+    const versionMatch = text.match(/version\s*=\s*"([^"]+)"/);
+    if (!versionMatch) {
+      return null;
+    }
+
+    let version = versionMatch[1];
+    const versionStart = text.indexOf('"', text.indexOf("version")) + 1;
+    const versionEnd = versionStart + version.length;
+
+    // Remove version constraint operators if present
+    version = version.replace(/^[~><=\s]+/, "").trim();
+
+    const item = new Item();
+    item.copyFrom(
+      moduleName,
+      version,
+      versionStart,
+      versionEnd,
+      line.lineNumber,
+      line.range.end.character
+    );
+    item.createRange();
+    item.createDecoRange();
+    return item;
+  }
+}

--- a/vscode/src/core/parsers/TerraformParser.ts
+++ b/vscode/src/core/parsers/TerraformParser.ts
@@ -1,22 +1,36 @@
 import { TextDocument, TextLine } from "vscode";
 import Item from "../Item";
-import { isQuote, shouldIgnoreLine } from "./utils";
+import { shouldIgnoreLine } from "./utils";
 import { Settings } from "../../config";
 
 class State {
   inModule: boolean;
   inModuleBlock: boolean;
-  currentModule: string;
+  moduleSource: string;
+  pendingVersionLine: TextLine | null;
   items: Item[];
   braceDepth: number;
 
   constructor() {
     this.inModule = false;
     this.inModuleBlock = false;
-    this.currentModule = "";
+    this.moduleSource = "";
+    this.pendingVersionLine = null;
     this.items = [] as Item[];
     this.braceDepth = 0;
   }
+}
+
+/** Registry modules use namespace/name/provider (exactly 3 path segments). */
+export function isTerraformRegistryModule(source: string): boolean {
+  if (!source || source.includes("://") || source.startsWith(".") || source.startsWith("/")) {
+    return false;
+  }
+  if (source.startsWith("git::") || source.startsWith("hg::") || source.startsWith("s3::") || source.startsWith("gcs::")) {
+    return false;
+  }
+  const parts = source.split("/");
+  return parts.length === 3 && parts.every((part) => part.length > 0);
 }
 
 export class TerraformParser {
@@ -34,18 +48,14 @@ export class TerraformParser {
       // Check for module block start
       const moduleMatch = text.match(/^module\s+"([^"]+)"\s*\{/);
       if (moduleMatch) {
-        state.inModule = true;
-        state.inModuleBlock = true;
-        state.currentModule = moduleMatch[1];
-        state.braceDepth = 1;
+        this.resetModuleState(state, true, 1);
         continue;
       }
 
       // Handle module block that starts without opening brace on same line
       const moduleMatchNoBrace = text.match(/^module\s+"([^"]+)"\s*$/);
       if (moduleMatchNoBrace) {
-        state.inModule = true;
-        state.currentModule = moduleMatchNoBrace[1];
+        this.resetModuleState(state, false, 0);
         continue;
       }
 
@@ -54,7 +64,8 @@ export class TerraformParser {
         // Check for opening brace if we haven't entered the block yet
         if (!state.inModuleBlock && text.includes("{")) {
           state.inModuleBlock = true;
-          state.braceDepth = 1;
+          // Count braces on this line only once (do not pre-set then re-count).
+          state.braceDepth = 0;
         }
 
         if (state.inModuleBlock) {
@@ -62,28 +73,36 @@ export class TerraformParser {
           state.braceDepth += (text.match(/{/g) || []).length;
           state.braceDepth -= (text.match(/}/g) || []).length;
 
-          // Parse source and version lines
           if (text.includes("source")) {
-            // source = "namespace/name/provider" or source = "..."
             const sourceMatch = text.match(/source\s*=\s*"([^"]+)"/);
             if (sourceMatch) {
-              state.currentModule = sourceMatch[1];
+              state.moduleSource = sourceMatch[1];
+              if (state.pendingVersionLine && isTerraformRegistryModule(state.moduleSource)) {
+                const item = this.parseVersionLine(state.pendingVersionLine, state.moduleSource);
+                if (item) {
+                  state.items.push(item);
+                }
+                state.pendingVersionLine = null;
+              }
             }
           }
 
           if (text.includes("version")) {
-            // version = "1.0.0" or version = ">= 1.0.0"
-            const item = this.parseVersionLine(line, state.currentModule);
-            if (item) {
-              state.items.push(item);
+            if (isTerraformRegistryModule(state.moduleSource)) {
+              const item = this.parseVersionLine(line, state.moduleSource);
+              if (item) {
+                state.items.push(item);
+              }
+            } else {
+              // source may appear after version in the block
+              state.pendingVersionLine = line;
             }
           }
 
           // Exit module block when all braces are closed
           if (state.braceDepth <= 0) {
+            this.resetModuleState(state, false, 0);
             state.inModule = false;
-            state.inModuleBlock = false;
-            state.currentModule = "";
           }
         }
       }
@@ -92,26 +111,33 @@ export class TerraformParser {
     return state.items;
   }
 
-  private parseVersionLine(line: TextLine, moduleName: string): Item | null {
-    const text = line.text;
-    const start = line.firstNonWhitespaceCharacterIndex;
+  private resetModuleState(state: State, inModuleBlock: boolean, braceDepth: number) {
+    state.inModule = true;
+    state.inModuleBlock = inModuleBlock;
+    state.moduleSource = "";
+    state.pendingVersionLine = null;
+    state.braceDepth = braceDepth;
+  }
 
-    // Match: version = "1.0.0" or version = ">= 1.0.0"
+  private parseVersionLine(line: TextLine, moduleSource: string): Item | null {
+    const text = line.text;
+
+    // Match: version = "1.0.0" or version = ">= 1.0.0" / "~> 5.0"
     const versionMatch = text.match(/version\s*=\s*"([^"]+)"/);
     if (!versionMatch) {
       return null;
     }
 
-    let version = versionMatch[1];
+    const rawVersion = versionMatch[1];
     const versionStart = text.indexOf('"', text.indexOf("version")) + 1;
-    const versionEnd = versionStart + version.length;
+    const versionEnd = versionStart + rawVersion.length;
 
-    // Remove version constraint operators if present
-    version = version.replace(/^[~><=\s]+/, "").trim();
+    // Normalize for comparison while keeping decoration range over the full quoted value.
+    const version = rawVersion.replace(/^[~><=\s]+/, "").trim();
 
     const item = new Item();
     item.copyFrom(
-      moduleName,
+      moduleSource,
       version,
       versionStart,
       versionEnd,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR adds support for Terraform module version management in `.tf` files, addressing issue #235.

## Changes

### Core Implementation
- **Language Support**: Added `Terraform` to the `Language` enum and `OCVEnvironment`
- **Parser**: `TerraformParser` parses module blocks and version declarations
- **Listener / Fetcher**: Wire-up for Terraform Registry API lookups
- **API**: `terraform.ts` queries `registry.terraform.io/v1/modules/.../versions`

### Configuration & Docs
- Version bumped to **0.7.27**
- Dedicated **Terraform Settings** section in `package.json`
- README + changelog updated

## Review (self)

Reviewed before merge. Fixed before marking ready:
1. Brace-depth double-count when `{` is on its own line
2. Local/git modules skipped instead of erroring
3. Version-before-source ordering supported
4. Terraform settings moved out of the Gradle settings section

Verified Registry API response shape and successful esbuild/tsc build.

## Merge status

Cannot merge from this agent: **main branch requires a human review approval** (`REVIEW_REQUIRED`). Auto-merge is also disabled on the repo.

Please approve [PR #304](https://github.com/filllabs/dependi/pull/304) to complete the merge.

## Resolves

Closes #235
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://filllabs.slack.com/archives/D097G18M3SM/p1785005393270689?thread_ts=1785005393.270689&cid=D097G18M3SM)

<div><a href="https://cursor.com/agents/bc-e0df5bfc-4180-520d-8d1b-12cd4dc606c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0df5bfc-4180-520d-8d1b-12cd4dc606c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

